### PR TITLE
Updating compatibility

### DIFF
--- a/DeLorean-Dark-3.18/gtk-3.0/gtk-contained.css
+++ b/DeLorean-Dark-3.18/gtk-3.0/gtk-contained.css
@@ -10,12 +10,6 @@
   -GtkExpander-expander-size: 16;
   -GtkTreeView-expander-size: 11;
   -GtkTreeView-horizontal-separator: 4;
-  -GtkMenu-horizontal-padding: 0;
-  -GtkMenu-vertical-padding: 0;
-  -GtkWidget-link-color: #2a76c6;
-  -GtkWidget-visited-link-color: #215d9c;
-  -GtkWidget-focus-padding: 2;
-  -GtkWidget-focus-line-width: 1;
   -GtkWidget-text-handle-width: 20;
   -GtkWidget-text-handle-height: 24;
   -GtkDialog-button-spacing: 4;
@@ -25,7 +19,7 @@
   outline-style: dashed;
   outline-offset: -3px;
   outline-width: 1px;
-  outline-radius: 2px; }
+  -gtk-outline-radius: 2px; }
 
 /***************
  * Base States *
@@ -36,7 +30,7 @@
   background-image: url("assets/background-dark.png"); }
   .background:backdrop {
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     color: @theme_unfocused_fg_color;
     background-color: transparent;
     background-image: url("assets/background-dark.png"); }
@@ -47,19 +41,19 @@
    or better, just don't.
    Everytime a wildcard is used a kitten dies, painfully.
 */
-*:insensitive {
-  -gtk-image-effect: dim; }
+*:disabled {
+  -gtk-icon-effect: dim; }
 
 .gtkstyle-fallback {
   background-color: #2c2c2e;
   color: @theme_fg_color; }
-  .gtkstyle-fallback:prelight {
+  .gtkstyle-fallback:hover {
     background-color: #323234;
     color: shade(@theme_fg_color, 1.2); }
   .gtkstyle-fallback:active {
     background-color: #202022;
     color: #fff; }
-  .gtkstyle-fallback:insensitive {
+  .gtkstyle-fallback:disabled {
     background-color: #39393b;
     color: @insensitive_fg_color; }
   .gtkstyle-fallback:selected {
@@ -83,9 +77,9 @@
   color: rgba(0,0,0,0.15); }
   .label.separator:backdrop {
     color: @theme_unfocused_fg_color; }
-.label:insensitive {
+.label:disabled {
   color: @insensitive_fg_color; }
-  .label:insensitive:backdrop {
+  .label:disabled:backdrop {
     color: @insesitive_fg_color; }
 
 .dim-label, .label.separator, .titlebar .subtitle,
@@ -112,11 +106,11 @@ GtkAssistant .sidebar .label.highlight {
 
 GtkTextView.view {
   background-color: #2c2c2e;
-  background-image: linear-gradient(to bottom, alpha(white, 0.45));
+  background-image: image(alpha(white, 0.45));
   color:black }
 GtkTextView.view:backdrop {
     background-color: #2c2c2e;
-    background-image: linear-gradient(to bottom, alpha(white, 0.2));
+    background-image: image(alpha(white, 0.2));
     color: shade(@theme_unfocused_fg_color,1.2); }
 
 GeditWindow GtkTextView.view,
@@ -141,7 +135,7 @@ GeditWindow GtkTextView.view:backdrop {
   outline-color: rgba(238, 238, 236, 0.3);
   box-shadow: none;
   text-shadow: 0 1px black;
-  icon-shadow: 0 1px black; }
+  -gtk-icon-shadow: 0 1px black; }
   .popover.osd:backdrop, .app-notification:backdrop, .osd .scale-popup:backdrop, .osd:backdrop {
     text-shadow: none; }
 
@@ -159,7 +153,7 @@ GeditWindow GtkTextView.view:backdrop {
   .spinner:active {
     opacity: 1;
     animation: spin 1s linear infinite; }
-    .spinner:active:insensitive {
+    .spinner:active:disabled {
       opacity: 0.5; }
 
 /****************
@@ -172,7 +166,7 @@ GeditWindow GtkTextView.view:backdrop {
   border-radius: 3px;
   transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
   background-color: #2c2c2e;
-  background-image: linear-gradient(to bottom, alpha(white, 0.35) 90%);
+  background-image: image(alpha(white, 0.35));
   color: black;
   border-color: rgba(0,0,0,0.28);
   box-shadow: 0 1px 3px 0 rgba(0,0,0,0.26); }
@@ -186,7 +180,7 @@ GeditWindow GtkTextView.view:backdrop {
   .entry.flat, .entry.flat:focus {
     padding: 2px;
     background-color: #2c2c2e;
-    background-image: linear-gradient(to bottom, alpha(white,0.4) 90%);
+    background-image: image(alpha(white,0.4));
     color: black;
     border-color: rgba(0,0,0,0.38);
     box-shadow: inset 0 0 0 1px rgba(74, 144, 217, 0);
@@ -195,25 +189,25 @@ GeditWindow GtkTextView.view:backdrop {
   .entry:focus,
   .header-bar .entry {
     background-color: #2c2c2e;
-    background-image: linear-gradient(to bottom, alpha(white,0.45) 90%);
+    background-image: image(alpha(white,0.45));
     box-shadow: 0 1px 3px 0 rgba(0,0,0,0.35);
     border-color: @theme_selected_bg_color; }
-  .entry:insensitive {
+  .entry:disabled {
     background-color: #2c2c2e;
-    background-image: linear-gradient(to bottom, alpha(white, 0.15) 90%);
+    background-image: image(alpha(white, 0.15));
     color: shade(@insensitive_fg_color,1.3);
     border-color: rgba(0,0,0,0.2);
     box-shadow: none; }
   .entry:backdrop,
   .header-bar .entry:backdrop {
     background-color: #2c2c2e;
-    background-image: linear-gradient(to bottom, alpha(white, 0.2) 90%);
+    background-image: image(alpha(white, 0.2));
     color: shade(@theme_unfocused_fg_color,1.2);
     border-color: rgba(0,0,0,0.2);
     box-shadow: 0 1px rgba(255, 255, 255, 0); }
-  .entry:backdrop:insensitive {
+  .entry:backdrop:disabled {
     background-color: #2c2c2e;
-    background-image: linear-gradient(to bottom, alpha(white, 0.05) 90%);
+    background-image: image(alpha(white, 0.05));
     color: #4a4a4d;
     border-color: rgba(0,0,0,0.2);
     box-shadow: 0 1px rgba(255, 255, 255, 0); }
@@ -241,7 +235,7 @@ GeditWindow GtkTextView.view:backdrop {
     border-color: #cc0000; }
     .entry.error:focus {
       background-color: transparent;
-      background-image: linear-gradient(to bottom, alpha(white, 0.6) 90%);
+      background-image: image(alpha(white, 0.6));
       box-shadow: inset 0 0 0 1px #cc0000, 0 1px 3px 0 rgba(0,0,0,0.5);
       border-color: #cc0000; }
     .entry.error:selected, .entry.error:selected:focus {
@@ -251,7 +245,7 @@ GeditWindow GtkTextView.view:backdrop {
     border-color: #f57900; }
     .entry.warning:focus {
       background-color: transparent;
-      background-image: linear-gradient(to bottom, alpha(white, 0.6) 90%);
+      background-image: image(alpha(white, 0.6));
       box-shadow: inset 0 0 0 1px #f57900, 0 1px 3px 0 rgba(0,0,0,0.5);
       border-color: #f57900; }
     .entry.warning:selected, .entry.warning:selected:focus {
@@ -268,49 +262,49 @@ GeditWindow GtkTextView.view:backdrop {
     background-color: transparent;
     color: white;
     border-color: rgba(0, 0, 0, 0.7);
-    background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.5));
+    background-image: image(rgba(0, 0, 0, 0.5));
     background-clip: padding-box;
     box-shadow: none;
     text-shadow: 0 1px black;
-    icon-shadow: 0 1px black; }
+    -gtk-icon-shadow: 0 1px black; }
     .osd .entry:focus {
       background-color: transparent;
       color: white;
       border-color: @theme_selected_bg_color;
-      background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.5));
+      background-image: image(rgba(0, 0, 0, 0.5));
       background-clip: padding-box;
       box-shadow: inset 0 0 0 1px alpha(@theme_selected_bg_color, 0.6);
       text-shadow: 0 1px black;
-      icon-shadow: 0 1px black; }
+      -gtk-icon-shadow: 0 1px black; }
     .osd .entry:backdrop {
       background-color: transparent;
       color: white;
       border-color: rgba(0, 0, 0, 0.7);
-      background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.5));
+      background-image: image(rgba(0, 0, 0, 0.5));
       background-clip: padding-box;
       box-shadow: none;
       text-shadow: none;
-      icon-shadow: none; }
-    .osd .entry:insensitive {
+      -gtk-icon-shadow: none; }
+    .osd .entry:disabled {
       background-color: transparent;
       color: @insensitive_fg_color;
       border-color: rgba(0, 0, 0, 0.7);
-      background-image: linear-gradient(to bottom, rgba(57, 57, 59, 0.5));
+      background-image: image(rgba(57, 57, 59, 0.5));
       background-clip: padding-box;
       box-shadow: none;
       text-shadow: none;
-      icon-shadow: none; }
+      -gtk-icon-shadow: none; }
 
 .linked.vertical > .entry:not(:last-child) {
   box-shadow: none; }
 .linked.vertical > .entry:focus:not(:last-child) {
   box-shadow: inset 0 0 0 1px @theme_selected_bg_color; }
-.linked.vertical > .entry:not(:insensitive) + .entry:not(:insensitive) {
+.linked.vertical > .entry:not(:disabled) + .entry:not(:disabled) {
   border-top-color: rgba(0,0,0,0.2);
-  background-image: linear-gradient(to bottom, alpha(white, 0.35)); }
-  .linked.vertical > .entry:not(:insensitive) + .entry:not(:insensitive):backdrop {
+  background-image: image(alpha(white, 0.35)); }
+  .linked.vertical > .entry:not(:disabled) + .entry:not(:disabled):backdrop {
     border-top-color: #e4e4e4;
-    background-image: linear-gradient(to bottom, alpha(white,0.25)); }
+    background-image: image(alpha(white,0.25)); }
 .linked.vertical > .entry + .entry:focus:not(:last-child) {
   border-top-color: @theme_selected_bg_color;
   box-shadow: none; }
@@ -354,7 +348,7 @@ GeditWindow GtkTextView.view:backdrop {
                                       shade(#3c3c3e, 0.9)
                                       );     
   text-shadow: 0 -1px rgba(0,0,0,0.7);
-  icon-shadow: 0 -1px rgba(0,0,0,0.7);                                   
+  -gtk-icon-shadow: 0 -1px rgba(0,0,0,0.7);                                   
   box-shadow: 0 1px alpha(white, 0.08) inset,
 				0 2px alpha(white, 0.04) inset,
 				1px 0 alpha(white, 0.03) inset,
@@ -383,7 +377,7 @@ color: #ccc;
                                       shade(#3c3c3e, 0.9)
                                       );     
   text-shadow: 0 -1px rgba(0,0,0,0.7);
-  icon-shadow: 0 -1px rgba(0,0,0,0.7);
+  -gtk-icon-shadow: 0 -1px rgba(0,0,0,0.7);
   box-shadow: 0 1px alpha(white, 0.08) inset,
 				0 2px alpha(white, 0.04) inset,
 				1px 0 alpha(white, 0.03) inset,
@@ -412,7 +406,7 @@ color: #ccc;
                                     alpha(white, 0.35),
                                     alpha(white, 0.20));
   box-shadow: inset 0 1px 2px 0px alpha(white, 0.6), inset 0 1px alpha(white,0.45), 0 1px 2px 0 alpha(black, 0.35);
-  icon-shadow: 0 1px rgba(255,255,255,0.45);
+  -gtk-icon-shadow: 0 1px rgba(255,255,255,0.45);
   text-shadow: 0 1px rgba(255,255,255,0.45);
 }
 
@@ -433,7 +427,7 @@ color: #ccc;
                                     alpha(white, 0.25),
                                     alpha(white, 0.10));
   box-shadow: inset 0 1px 2px 0px alpha(white, 0.3), inset 0 1px alpha(white,0.25), 0 1px 2px 0 alpha(black, 0.15);
-  icon-shadow: none;
+  -gtk-icon-shadow: none;
   text-shadow: none;
 }
 
@@ -455,13 +449,13 @@ color: #ccc;
                                     alpha(white, 0.10),
                                     alpha(white, 0.25));
   box-shadow: inset 0 1px 2px 0 alpha(black, 0.35), 0 1px alpha(white, 0.65);
-  icon-shadow: none;
+  -gtk-icon-shadow: none;
   text-shadow: none;
 }
 
 .titlebar .button:hover,
 .header-bar .button:hover {
-  icon-shadow: 0 1px 3px rgba(255,255,255,0.95), 0 -1px 3px rgba(255,255,255,0.95);
+  -gtk-icon-shadow: 0 1px 3px rgba(255,255,255,0.95), 0 -1px 3px rgba(255,255,255,0.95);
   text-shadow: 0 1px 3px rgba(255,255,255,0.95), 0 -1px 3px rgba(255,255,255,0.95);
   }
 	
@@ -476,14 +470,14 @@ color:black;
                                     alpha(white, 0.35),
                                     alpha(white, 0.55));
   box-shadow: inset 0 1px 2px 0 alpha(black, 0.35), 0 1px alpha(white, 0.65);
-  icon-shadow: 0 1px rgba(255,255,255,0.45);
+  -gtk-icon-shadow: 0 1px rgba(255,255,255,0.45);
   text-shadow: 0 1px rgba(255,255,255,0.45);
   }
   
-.titlebar .button:insensitive,
-.header-bar .button:insensitive,
-.titlebar .button:insensitive:backdrop,
-.header-bar .button:insensitive:backdrop {
+.titlebar .button:disabled,
+.header-bar .button:disabled,
+.titlebar .button:disabled:backdrop,
+.header-bar .button:disabled:backdrop {
   border-top-color: alpha(black, 0.2);
   border-right-color: alpha(black,0.35);
   border-bottom-color: alpha(black, 0.45);
@@ -499,7 +493,7 @@ color:black;
                                     alpha(white, 0.15),
                                     alpha(white, 0.05));
   box-shadow: inset 0 1px 2px 0px alpha(white, 0.15), inset 0 1px alpha(white,0.12), 0 1px 2px 0 alpha(black, 0.08);
-  icon-shadow: none;
+  -gtk-icon-shadow: none;
   text-shadow: none;
 }
 				
@@ -510,7 +504,7 @@ color:black;
     background-image: none;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0);
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     transition: none; }
     .button.flat:hover, .sidebar-button.button:hover, .header-bar .titlebutton.button:hover,
     .titlebar .titlebutton.button:hover {
@@ -548,8 +542,8 @@ color:black;
 				0 -3px alpha(black, 0.01) inset,
 				0 1px 2px 0 rgba(0,0,0,0.2); 
     text-shadow: 0 1px rgba(0,0,0, 0.76923);
-    icon-shadow: 0 1px rgba(0,0,0, 0.76923);
-    -gtk-image-effect: highlight; }
+    -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923);
+    -gtk-icon-effect: highlight; }
     
   .button:active, .header-bar .button.titlebutton:active,
   .titlebar .button.titlebutton:active, .button:checked, .header-bar .button.titlebutton:checked,
@@ -565,7 +559,7 @@ color:black;
                                       mix(shade(#3c3c3e, 1.2), @theme_selected_bg_color, 0.25));
     background-color: transparent;
     text-shadow: 0 1px rgba(0,0,0, 0.76923);
-    icon-shadow: 0 1px rgba(0,0,0, 0.76923);
+    -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923);
     box-shadow: inset 0 1px rgba(0, 0, 0, 0.07), inset 0 2px 1px -2px rgba(0, 0, 0, 0.6), 0 1px alpha(white,0.12);
     transition-duration: 50ms; }
     
@@ -603,8 +597,8 @@ color:black;
 				0 -2px alpha(black, 0.01) inset,
 				0 -3px alpha(black, 0.005) inset;
     text-shadow: none;
-    icon-shadow: none;
-    -gtk-image-effect: none; }
+    -gtk-icon-shadow: none;
+    -gtk-icon-effect: none; }
     .button:backdrop:active, .button:backdrop:checked, .button.flat:backdrop:active, .sidebar-button.button:backdrop:active, .header-bar .titlebutton.button:backdrop:active,
     .titlebar .titlebutton.button:backdrop:active, .button.flat:backdrop:checked, .sidebar-button.button:backdrop:checked, .header-bar .titlebutton.button:backdrop:checked,
     .titlebar .titlebutton.button:backdrop:checked,
@@ -619,68 +613,68 @@ color:black;
                                       shade( mix(shade(#3c3c3e, 0.9), @theme_selected_bg_color, 0.20), 0.8), 
                                       shade( mix(shade(#3c3c3e, 1.2), @theme_selected_bg_color, 0.20), 0.8));
       box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0); }
-    .button:backdrop:insensitive, .button.flat:backdrop:insensitive, .sidebar-button.button:backdrop:insensitive, .header-bar .titlebutton.button:backdrop:insensitive,
-    .titlebar .titlebutton.button:backdrop:insensitive,
-      .titlebar .stack-switcher .button:backdrop:insensitive,
-.header-bar .stack-switcher .button:backdrop:insensitive {
+    .button:backdrop:disabled, .button.flat:backdrop:disabled, .sidebar-button.button:backdrop:disabled, .header-bar .titlebutton.button:backdrop:disabled,
+    .titlebar .titlebutton.button:backdrop:disabled,
+      .titlebar .stack-switcher .button:backdrop:disabled,
+.header-bar .stack-switcher .button:backdrop:disabled {
       color: #4a4a4d;
       border-color: #202022;
-      background-image: linear-gradient(to bottom, #2a2a2c);
+      background-image: image(#2a2a2c);
       text-shadow: none;
-      icon-shadow: none;
+      -gtk-icon-shadow: none;
       box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0); }
-      .button:backdrop:insensitive > .label, .button.flat:backdrop:insensitive > .label, .sidebar-button.button:backdrop:insensitive > .label, .header-bar .titlebutton.button:backdrop:insensitive > .label,
-      .titlebar .titlebutton.button:backdrop:insensitive > .label {
+      .button:backdrop:disabled > .label, .button.flat:backdrop:disabled > .label, .sidebar-button.button:backdrop:disabled > .label, .header-bar .titlebutton.button:backdrop:disabled > .label,
+      .titlebar .titlebutton.button:backdrop:disabled > .label {
         color: inherit; }
-    .button:backdrop:insensitive:active, .button:backdrop:insensitive:checked, .button.flat:backdrop:insensitive:active, .sidebar-button.button:backdrop:insensitive:active, .header-bar .titlebutton.button:backdrop:insensitive:active,
-    .titlebar .titlebutton.button:backdrop:insensitive:active, .button.flat:backdrop:insensitive:checked, .sidebar-button.button:backdrop:insensitive:checked, .header-bar .titlebutton.button:backdrop:insensitive:checked,
-    .titlebar .titlebutton.button:backdrop:insensitive:checked,
-      .titlebar .stack-switcher .button:backdrop:insensitive:active,
-.header-bar .stack-switcher .button:backdrop:insensitive:active,
-  .titlebar .stack-switcher .button:backdrop:insensitive:checked,
-.header-bar .stack-switcher .button:backdrop:insensitive:checked {
+    .button:backdrop:disabled:active, .button:backdrop:disabled:checked, .button.flat:backdrop:disabled:active, .sidebar-button.button:backdrop:disabled:active, .header-bar .titlebutton.button:backdrop:disabled:active,
+    .titlebar .titlebutton.button:backdrop:disabled:active, .button.flat:backdrop:disabled:checked, .sidebar-button.button:backdrop:disabled:checked, .header-bar .titlebutton.button:backdrop:disabled:checked,
+    .titlebar .titlebutton.button:backdrop:disabled:checked,
+      .titlebar .stack-switcher .button:backdrop:disabled:active,
+.header-bar .stack-switcher .button:backdrop:disabled:active,
+  .titlebar .stack-switcher .button:backdrop:disabled:checked,
+.header-bar .stack-switcher .button:backdrop:disabled:checked {
       color: #7a7a7d;
       border-color: #202022;
       background-image: linear-gradient(to bottom, #262628, #2c2c2f);
       box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0); }
-      .button:backdrop:insensitive:active > .label, .button:backdrop:insensitive:checked > .label, .button.flat:backdrop:insensitive:active > .label, .sidebar-button.button:backdrop:insensitive:active > .label, .header-bar .titlebutton.button:backdrop:insensitive:active > .label,
-      .titlebar .titlebutton.button:backdrop:insensitive:active > .label, .button.flat:backdrop:insensitive:checked > .label, .sidebar-button.button:backdrop:insensitive:checked > .label, .header-bar .titlebutton.button:backdrop:insensitive:checked > .label,
-      .titlebar .titlebutton.button:backdrop:insensitive:checked > .label {
+      .button:backdrop:disabled:active > .label, .button:backdrop:disabled:checked > .label, .button.flat:backdrop:disabled:active > .label, .sidebar-button.button:backdrop:disabled:active > .label, .header-bar .titlebutton.button:backdrop:disabled:active > .label,
+      .titlebar .titlebutton.button:backdrop:disabled:active > .label, .button.flat:backdrop:disabled:checked > .label, .sidebar-button.button:backdrop:disabled:checked > .label, .header-bar .titlebutton.button:backdrop:disabled:checked > .label,
+      .titlebar .titlebutton.button:backdrop:disabled:checked > .label {
         color: inherit; }
   .button.flat:backdrop, .sidebar-button.button:backdrop, .header-bar .titlebutton.button:backdrop,
-  .titlebar .titlebutton.button:backdrop, .button.flat:insensitive, .sidebar-button.button:insensitive, .header-bar .titlebutton.button:insensitive,
-  .titlebar .titlebutton.button:insensitive, .button.flat:backdrop:insensitive, .sidebar-button.button:backdrop:insensitive, .header-bar .titlebutton.button:backdrop:insensitive,
-  .titlebar .titlebutton.button:backdrop:insensitive,
-    .titlebar .stack-switcher .button:backdrop:insensitive,
-.header-bar .stack-switcher .button:backdrop:insensitive {
+  .titlebar .titlebutton.button:backdrop, .button.flat:disabled, .sidebar-button.button:disabled, .header-bar .titlebutton.button:disabled,
+  .titlebar .titlebutton.button:disabled, .button.flat:backdrop:disabled, .sidebar-button.button:backdrop:disabled, .header-bar .titlebutton.button:backdrop:disabled,
+  .titlebar .titlebutton.button:backdrop:disabled,
+    .titlebar .stack-switcher .button:backdrop:disabled,
+.header-bar .stack-switcher .button:backdrop:disabled {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0);
     text-shadow: none;
-    icon-shadow: none; }
-  .button:insensitive, .header-bar .button.titlebutton:insensitive,
-  .titlebar .button.titlebutton:insensitive,
-    .titlebar .stack-switcher .button:insensitive,
-.header-bar .stack-switcher .button:insensitive {
+    -gtk-icon-shadow: none; }
+  .button:disabled, .header-bar .button.titlebutton:disabled,
+  .titlebar .button.titlebutton:disabled,
+    .titlebar .stack-switcher .button:disabled,
+.header-bar .stack-switcher .button:disabled {
     color: @insensitive_fg_color;
     border-color: #1c1c1f;
-    background-image: linear-gradient(to bottom, #2c2c2e);
+    background-image: image(#2c2c2e);
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px alpha(white,0.08); }
-    .button:insensitive > .label {
+    .button:disabled > .label {
       color: inherit; }
-    .button:insensitive:active, .button:insensitive:checked,
-      .titlebar .stack-switcher .button:insensitive:active,
-.header-bar .stack-switcher .button:insensitive:active,
-  .titlebar .stack-switcher .button:insensitive:checked,
-.header-bar .stack-switcher .button:insensitive:checked {
+    .button:disabled:active, .button:disabled:checked,
+      .titlebar .stack-switcher .button:disabled:active,
+.header-bar .stack-switcher .button:disabled:active,
+  .titlebar .stack-switcher .button:disabled:checked,
+.header-bar .stack-switcher .button:disabled:checked {
       color: @insensitive_fg_color;
       border-color: #1c1c1f;
       background-image: linear-gradient(to bottom, #242426, #2c2c2e);
       box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px alpha(white,0.08); }
-      .button:insensitive:active > .label, .button:insensitive:checked > .label {
+      .button:disabled:active > .label, .button:disabled:checked > .label {
         color: inherit; }
   .button.osd, .header-bar .osd.button.titlebutton,
   .titlebar .osd.button.titlebutton {
@@ -688,11 +682,11 @@ color:black;
     border-radius: 5px;
     outline-color: rgba(238, 238, 236, 0.3);
     border-color: rgba(0, 0, 0, 0.7);
-    background-image: linear-gradient(to bottom, rgba(15,15,16, 0.5));
+    background-image: image(rgba(15,15,16, 0.5));
     background-clip: padding-box;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0.06);
     text-shadow: 0 1px black;
-    icon-shadow: 0 1px black;
+    -gtk-icon-shadow: 0 1px black;
     border-style:solid;
     border-width: 1px;
     border-color: rgba(0, 0, 0, 0.7);
@@ -707,11 +701,11 @@ color:black;
     border-width: 1px;
     border-color: rgba(0, 0, 0, 0.7);
     border-radius: 3px;
-      background-image: linear-gradient(to bottom, rgba(255,255,255, 0.7));
+      background-image: image(rgba(255,255,255, 0.7));
       background-clip: padding-box;
       box-shadow: inset 0 1px rgba(255, 255, 255, 0.08);
       text-shadow: 0 1px black;
-      icon-shadow: 0 1px black;
+      -gtk-icon-shadow: 0 1px black;
       outline-color: rgba(238, 238, 236, 0.3);}
     .button.osd:active, .button.osd:checked {
       color: white;
@@ -719,20 +713,20 @@ color:black;
     border-width: 1px;
     border-color: rgba(0, 0, 0, 0.7);
     border-radius: 3px;
-      background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.7));
+      background-image: image(rgba(0, 0, 0, 0.7));
       background-clip: padding-box;
       box-shadow: 0 1px alpha(white, 0.08);
       text-shadow: none;
-      icon-shadow: 0 1px alpha(black,0.4);
+      -gtk-icon-shadow: 0 1px alpha(black,0.4);
       outline-color: rgba(238, 238, 236, 0.3);}
-    .button.osd:insensitive, .button.osd:backdrop:insensitive {
+    .button.osd:disabled, .button.osd:backdrop:disabled {
       color: @insensitive_fg_color;
       border-color: transparent;
-      background-image: linear-gradient(to bottom, rgba(15,15,19, 0.0));
+      background-image: image(rgba(15,15,19, 0.0));
       background-clip: padding-box;
       box-shadow: none;
       text-shadow: none;
-      icon-shadow: 0 1px alpha(black,0.4);
+      -gtk-icon-shadow: 0 1px alpha(black,0.4);
       border: none; }
     .button.osd:backdrop {
       color: #eeeeec;
@@ -740,11 +734,11 @@ color:black;
     border-width: 1px;
     border-color: rgba(0, 0, 0, 0.7);
     border-radius: 3px;
-      background-image: linear-gradient(to bottom, rgba(15,15,19, 0.4));
+      background-image: image(rgba(15,15,19, 0.4));
       background-clip: padding-box;
       box-shadow: none;
       text-shadow: none;
-      icon-shadow: none;
+      -gtk-icon-shadow: none;
       border: none; }
   .osd .button, .osd .header-bar .button.titlebutton, .header-bar .osd .button.titlebutton,
   .osd .titlebar .button.titlebutton,
@@ -754,11 +748,11 @@ color:black;
     border-width: 1px;
     border-color: rgba(0, 0, 0, 0.7);
     background-color: transparent;
-    background-image: linear-gradient(to bottom, rgba(15,15,16, 0.5));
+    background-image: image(rgba(15,15,16, 0.5));
     background-clip: padding-box;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0.06);
     text-shadow: 0 1px black;
-    icon-shadow: 0 1px black;
+    -gtk-icon-shadow: 0 1px black;
     outline-color: rgba(238, 238, 236, 0.3);
     border-radius: 3px;}
     /*.osd .button:dir(rtl) {
@@ -783,11 +777,11 @@ color:black;
     border-color: rgba(0, 0, 0, 0.7);
     border-radius: 3px;
       background-color: transparent;
-      background-image: linear-gradient(to bottom, rgba(255,255,255, 0.7));
+      background-image: image(rgba(255,255,255, 0.7));
       background-clip: padding-box;
       box-shadow: inset 0 1px rgba(255, 255, 255, 0.08);
       text-shadow: 0 1px black;
-      icon-shadow: 0 1px black;
+      -gtk-icon-shadow: 0 1px black;
       outline-color: rgba(238, 238, 236, 0.3); }
     .osd .button:active:active, .osd .button:checked:checked, .osd .button:backdrop:active:active, .osd .button:backdrop:checked:checked {
       color: white;
@@ -796,21 +790,21 @@ color:black;
     border-color: rgba(0, 0, 0, 0.7);
     border-radius: 3px;
       background-color: transparent;
-      background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.7));
+      background-image: image(rgba(0, 0, 0, 0.7));
       background-clip: padding-box;
       box-shadow: 0 1px alpha(white, 0.08);
       text-shadow: none;
-      icon-shadow: 0 1px alpha(black,0.4);
+      -gtk-icon-shadow: 0 1px alpha(black,0.4);
       outline-color: rgba(238, 238, 236, 0.3); }
-    .osd .button:insensitive:insensitive, .osd .button:backdrop:insensitive:backdrop:insensitive {
+    .osd .button:disabled:disabled, .osd .button:backdrop:disabled:backdrop:disabled {
       color: shade(@insensitive_fg_color,1.4);
       border-color: transparent;
       background-color: transparent;
-      background-image: linear-gradient(to bottom, rgba(15,15,19, 0.0));
+      background-image: image(rgba(15,15,19, 0.0));
       background-clip: padding-box;
       box-shadow: none;
       text-shadow: none;
-      icon-shadow: 0 1px alpha(black,0.4); }
+      -gtk-icon-shadow: 0 1px alpha(black,0.4); }
     .osd .button:backdrop:backdrop {
       color: @theme_unfocused_fg_color;
       border-style:solid;
@@ -818,11 +812,11 @@ color:black;
     border-color: rgba(0, 0, 0, 0.7);
     border-radius: 3px;
       background-color: transparent;
-      background-image: linear-gradient(to bottom, rgba(15,15,19, 0.4));
+      background-image: image(rgba(15,15,19, 0.4));
       background-clip: padding-box;
       box-shadow: none;
       text-shadow: none;
-      icon-shadow: none; }
+      -gtk-icon-shadow: none; }
     .osd .button.flat, .osd .sidebar-button.button, .osd .header-bar .titlebutton.button, .header-bar .osd .titlebutton.button,
     .osd .titlebar .titlebutton.button,
     .titlebar .osd .titlebutton.button {
@@ -831,10 +825,10 @@ color:black;
       background-image: none;
       box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0);
       text-shadow: none;
-      icon-shadow: none;
+      -gtk-icon-shadow: none;
       box-shadow: none;
       text-shadow: 0 1px black;
-      icon-shadow: 0 1px black; }
+      -gtk-icon-shadow: 0 1px black; }
       .osd .button.flat:hover, .osd .sidebar-button.button:hover, .osd .header-bar .titlebutton.button:hover, .header-bar .osd .titlebutton.button:hover,
       .osd .titlebar .titlebutton.button:hover,
       .titlebar .osd .titlebutton.button:hover {
@@ -843,25 +837,25 @@ color:black;
     border-width: 1px;
     border-color: rgba(0, 0, 0, 0.7);
     border-radius: 3px;
-        background-image: linear-gradient(to bottom, rgba(255,255,255, 0.7));
+        background-image: image(rgba(255,255,255, 0.7));
         background-clip: padding-box;
         box-shadow: inset 0 1px rgba(255, 255, 255, 0.08);
         text-shadow: 0 1px black;
-        icon-shadow: 0 1px black;
+        -gtk-icon-shadow: 0 1px black;
         outline-color: rgba(238, 238, 236, 0.3);
         background-clip: padding-box;
         
         box-shadow: none; }
-      .osd .button.flat:insensitive, .osd .sidebar-button.button:insensitive, .osd .header-bar .titlebutton.button:insensitive, .header-bar .osd .titlebutton.button:insensitive,
-      .osd .titlebar .titlebutton.button:insensitive,
-      .titlebar .osd .titlebutton.button:insensitive {
+      .osd .button.flat:disabled, .osd .sidebar-button.button:disabled, .osd .header-bar .titlebutton.button:disabled, .header-bar .osd .titlebutton.button:disabled,
+      .osd .titlebar .titlebutton.button:disabled,
+      .titlebar .osd .titlebutton.button:disabled {
         color: @insensitive_fg_color;
         border-color: transparent;
-        background-image: linear-gradient(to bottom, rgba(15,15,19, 0.0));
+        background-image: image(rgba(15,15,19, 0.0));
         background-clip: padding-box;
         box-shadow: none;
         text-shadow: none;
-        icon-shadow: 0 1px alpha(black,0.4);
+        -gtk-icon-shadow: 0 1px alpha(black,0.4);
         background-image: none;
         border-color: transparent;
         box-shadow: none; }
@@ -873,7 +867,7 @@ color:black;
         background-image: none;
         box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0);
         text-shadow: none;
-        icon-shadow: none; }
+        -gtk-icon-shadow: none; }
       .osd .button.flat:active, .osd .sidebar-button.button:active, .osd .header-bar .titlebutton.button:active, .header-bar .osd .titlebutton.button:active,
       .osd .titlebar .titlebutton.button:active,
       .titlebar .osd .titlebutton.button:active, .osd .button.flat:checked, .osd .sidebar-button.button:checked, .osd .header-bar .titlebutton.button:checked, .header-bar .osd .titlebutton.button:checked,
@@ -881,11 +875,11 @@ color:black;
       .titlebar .osd .titlebutton.button:checked {
         color: white;
         border-color: rgba(0, 0, 0, 0.9);
-        background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.7));
+        background-image: image(rgba(0, 0, 0, 0.7));
         background-clip: padding-box;
         box-shadow: none;
         text-shadow: none;
-        icon-shadow: 0 1px alpha(black,0.4);
+        -gtk-icon-shadow: 0 1px alpha(black,0.4);
         outline-color: rgba(238, 238, 236, 0.3);
         background-clip: padding-box;
         border-style:solid;
@@ -922,7 +916,7 @@ color:black;
 				0 -3px alpha(black, 0.01) inset,
 				0 1px alpha(white, 0.08);
     text-shadow: 0 -1px rgba(0, 0, 0, 0.54353);
-    icon-shadow: 0 -1px rgba(0, 0, 0, 0.54353); }
+    -gtk-icon-shadow: 0 -1px rgba(0, 0, 0, 0.54353); }
     .button.suggested-action.flat, .suggested-action.sidebar-button.button, .header-bar .suggested-action.titlebutton.button,
     .titlebar .suggested-action.titlebutton.button {
       border-color: transparent;
@@ -930,7 +924,7 @@ color:black;
       background-image: none;
       box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0);
       text-shadow: none;
-      icon-shadow: none;
+      -gtk-icon-shadow: none;
       color: @theme_selected_bg_color; }
     .button.suggested-action:hover {
       color: white;
@@ -959,7 +953,7 @@ color:black;
 				0 -3px alpha(black, 0.01) inset,
 				0 1px 2px 0 rgba(0,0,0,0.2);
       text-shadow: 0 -1px rgba(0, 0, 0, 0.51153);
-      icon-shadow: 0 -1px rgba(0, 0, 0, 0.51153); }
+      -gtk-icon-shadow: 0 -1px rgba(0, 0, 0, 0.51153); }
     .button.suggested-action:active, .button.suggested-action:checked {
       color: white;
       outline-color: rgba(255, 255, 255, 0.3);
@@ -969,7 +963,7 @@ color:black;
                                       mix(shade(@theme_selected_bg_color, 1.2), @theme_selected_bg_color, 0.25));
       background-color: transparent;
       text-shadow: 0 -1px rgba(0, 0, 0, 0.62353);
-      icon-shadow: 0 -1px rgba(0, 0, 0, 0.62353);
+      -gtk-icon-shadow: 0 -1px rgba(0, 0, 0, 0.62353);
       box-shadow: inset 0 1px rgba(0, 0, 0, 0.07), inset 0 2px 1px -2px rgba(0, 0, 0, 0.6), 0 1px alpha(white,0.12); }
     .button.suggested-action:backdrop, .button.suggested-action.flat:backdrop, .suggested-action.sidebar-button.button:backdrop, .header-bar .suggested-action.titlebutton.button:backdrop,
     .titlebar .suggested-action.titlebutton.button:backdrop {
@@ -997,7 +991,7 @@ color:black;
 				0 -2px alpha(black, 0.01) inset,
 				0 -3px alpha(black, 0.005) inset;
       text-shadow: none;
-      icon-shadow: none; }
+      -gtk-icon-shadow: none; }
       .button.suggested-action:backdrop:active, .button.suggested-action:backdrop:checked, .button.suggested-action.flat:backdrop:active, .suggested-action.sidebar-button.button:backdrop:active, .header-bar .suggested-action.titlebutton.button:backdrop:active,
       .titlebar .suggested-action.titlebutton.button:backdrop:active, .button.suggested-action.flat:backdrop:checked, .suggested-action.sidebar-button.button:backdrop:checked, .header-bar .suggested-action.titlebutton.button:backdrop:checked,
       .titlebar .suggested-action.titlebutton.button:backdrop:checked {
@@ -1007,98 +1001,98 @@ color:black;
                                       shade( mix(shade(@theme_selected_bg_color, 0.9), @theme_selected_bg_color, 0.20), 0.8), 
                                       shade( mix(shade(@theme_selected_bg_color, 1.2), @theme_selected_bg_color, 0.20), 0.8));
         box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0); }
-      .button.suggested-action:backdrop:insensitive, .button.suggested-action.flat:backdrop:insensitive, .suggested-action.sidebar-button.button:backdrop:insensitive, .header-bar .suggested-action.titlebutton.button:backdrop:insensitive,
-      .titlebar .suggested-action.titlebutton.button:backdrop:insensitive {
+      .button.suggested-action:backdrop:disabled, .button.suggested-action.flat:backdrop:disabled, .suggested-action.sidebar-button.button:backdrop:disabled, .header-bar .suggested-action.titlebutton.button:backdrop:disabled,
+      .titlebar .suggested-action.titlebutton.button:backdrop:disabled {
         color: #4a4a4d;
         border-color: #202022;
-        background-image: linear-gradient(to bottom, #262628);
+        background-image: image(#262628);
         text-shadow: none;
-        icon-shadow: none;
+        -gtk-icon-shadow: none;
         box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0); }
-        .button.suggested-action:backdrop:insensitive > .label, .button.suggested-action.flat:backdrop:insensitive > .label, .suggested-action.sidebar-button.button:backdrop:insensitive > .label, .header-bar .suggested-action.titlebutton.button:backdrop:insensitive > .label,
-        .titlebar .suggested-action.titlebutton.button:backdrop:insensitive > .label {
+        .button.suggested-action:backdrop:disabled > .label, .button.suggested-action.flat:backdrop:disabled > .label, .suggested-action.sidebar-button.button:backdrop:disabled > .label, .header-bar .suggested-action.titlebutton.button:backdrop:disabled > .label,
+        .titlebar .suggested-action.titlebutton.button:backdrop:disabled > .label {
           color: inherit; }
-        .button.suggested-action:backdrop:insensitive:active, .button.suggested-action:backdrop:insensitive:checked, .button.suggested-action.flat:backdrop:insensitive:active, .suggested-action.sidebar-button.button:backdrop:insensitive:active, .header-bar .suggested-action.titlebutton.button:backdrop:insensitive:active,
-        .titlebar .suggested-action.titlebutton.button:backdrop:insensitive:active, .button.suggested-action.flat:backdrop:insensitive:checked, .suggested-action.sidebar-button.button:backdrop:insensitive:checked, .header-bar .suggested-action.titlebutton.button:backdrop:insensitive:checked,
-        .titlebar .suggested-action.titlebutton.button:backdrop:insensitive:checked {
+        .button.suggested-action:backdrop:disabled:active, .button.suggested-action:backdrop:disabled:checked, .button.suggested-action.flat:backdrop:disabled:active, .suggested-action.sidebar-button.button:backdrop:disabled:active, .header-bar .suggested-action.titlebutton.button:backdrop:disabled:active,
+        .titlebar .suggested-action.titlebutton.button:backdrop:disabled:active, .button.suggested-action.flat:backdrop:disabled:checked, .suggested-action.sidebar-button.button:backdrop:disabled:checked, .header-bar .suggested-action.titlebutton.button:backdrop:disabled:checked,
+        .titlebar .suggested-action.titlebutton.button:backdrop:disabled:checked {
           color: #7a7a7d;
       border-color: #202022;
-      background-image: linear-gradient(to bottom, #2a2a2c);
+      background-image: image(#2a2a2c);
           box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0); }
-          .button.suggested-action:backdrop:insensitive:active > .label, .button.suggested-action:backdrop:insensitive:checked > .label, .button.suggested-action.flat:backdrop:insensitive:active > .label, .suggested-action.sidebar-button.button:backdrop:insensitive:active > .label, .header-bar .suggested-action.titlebutton.button:backdrop:insensitive:active > .label,
-          .titlebar .suggested-action.titlebutton.button:backdrop:insensitive:active > .label, .button.suggested-action.flat:backdrop:insensitive:checked > .label, .suggested-action.sidebar-button.button:backdrop:insensitive:checked > .label, .header-bar .suggested-action.titlebutton.button:backdrop:insensitive:checked > .label,
-          .titlebar .suggested-action.titlebutton.button:backdrop:insensitive:checked > .label {
+          .button.suggested-action:backdrop:disabled:active > .label, .button.suggested-action:backdrop:disabled:checked > .label, .button.suggested-action.flat:backdrop:disabled:active > .label, .suggested-action.sidebar-button.button:backdrop:disabled:active > .label, .header-bar .suggested-action.titlebutton.button:backdrop:disabled:active > .label,
+          .titlebar .suggested-action.titlebutton.button:backdrop:disabled:active > .label, .button.suggested-action.flat:backdrop:disabled:checked > .label, .suggested-action.sidebar-button.button:backdrop:disabled:checked > .label, .header-bar .suggested-action.titlebutton.button:backdrop:disabled:checked > .label,
+          .titlebar .suggested-action.titlebutton.button:backdrop:disabled:checked > .label {
             color: inherit; }
     .button.suggested-action.flat:backdrop, .suggested-action.sidebar-button.button:backdrop, .header-bar .suggested-action.titlebutton.button:backdrop,
-    .titlebar .suggested-action.titlebutton.button:backdrop, .button.suggested-action.flat:insensitive, .suggested-action.sidebar-button.button:insensitive, .header-bar .suggested-action.titlebutton.button:insensitive,
-    .titlebar .suggested-action.titlebutton.button:insensitive, .button.suggested-action.flat:backdrop:insensitive, .suggested-action.sidebar-button.button:backdrop:insensitive, .header-bar .suggested-action.titlebutton.button:backdrop:insensitive,
-    .titlebar .suggested-action.titlebutton.button:backdrop:insensitive {
+    .titlebar .suggested-action.titlebutton.button:backdrop, .button.suggested-action.flat:disabled, .suggested-action.sidebar-button.button:disabled, .header-bar .suggested-action.titlebutton.button:disabled,
+    .titlebar .suggested-action.titlebutton.button:disabled, .button.suggested-action.flat:backdrop:disabled, .suggested-action.sidebar-button.button:backdrop:disabled, .header-bar .suggested-action.titlebutton.button:backdrop:disabled,
+    .titlebar .suggested-action.titlebutton.button:backdrop:disabled {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
       box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0);
       text-shadow: none;
-      icon-shadow: none;
+      -gtk-icon-shadow: none;
       color: rgba(74, 144, 217, 0.8); }
-    .button.suggested-action:insensitive {
+    .button.suggested-action:disabled {
       color: @insensitive_fg_color;
     border-color: #1c1c1f;
-    background-image: linear-gradient(to bottom, #2c2c2e);
+    background-image: image(#2c2c2e);
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px alpha(white,0.08); }
-      .button.suggested-action:insensitive > .label {
+      .button.suggested-action:disabled > .label {
         color: inherit; }
-      .button.suggested-action:insensitive:active, .button.suggested-action:insensitive:checked {
+      .button.suggested-action:disabled:active, .button.suggested-action:disabled:checked {
         color: @insensitive_fg_color;
       border-color: #1c1c1f;
       background-image: linear-gradient(to bottom, #242426, #2c2c2e);
       box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px alpha(white,0.08); }
-        .button.suggested-action:insensitive:active > .label, .button.suggested-action:insensitive:checked > .label {
+        .button.suggested-action:disabled:active > .label, .button.suggested-action:disabled:checked > .label {
           color: inherit; }
     .osd .button.suggested-action {
       color: #eeeeec;
       border-color: rgba(0, 0, 0, 0.7);
-      background-image: linear-gradient(to bottom, rgba(15,15,16, 0.5));
+      background-image: image(rgba(15,15,16, 0.5));
       background-clip: padding-box;
       box-shadow: inset 0 1px rgba(255, 255, 255, 0.1);
       text-shadow: 0 1px black;
-      icon-shadow: 0 1px black;
+      -gtk-icon-shadow: 0 1px black;
       outline-color: rgba(238, 238, 236, 0.3); }
       .osd .button.suggested-action:hover {
         color: white;
         border-color: rgba(0, 0, 0, 0.7);
-        background-image: linear-gradient(to bottom, rgba(15,15,16, 0.7));
+        background-image: image(rgba(15,15,16, 0.7));
         background-clip: padding-box;
         box-shadow: inset 0 1px rgba(255, 255, 255, 0.1);
         text-shadow: 0 1px black;
-        icon-shadow: 0 1px black;
+        -gtk-icon-shadow: 0 1px black;
         outline-color: rgba(238, 238, 236, 0.3); }
       .osd .button.suggested-action:active, .osd .button.suggested-action:checked, .osd .button.suggested-action:backdrop:active, .osd .button.suggested-action:backdrop:checked {
         color: white;
         border-color: rgba(0, 0, 0, 0.7);
-        background-image: linear-gradient(to bottom, @theme_selected_bg_color);
+        background-image: image(@theme_selected_bg_color);
         background-clip: padding-box;
         box-shadow: none;
         text-shadow: none;
-        icon-shadow: 0 1px alpha(black, 0.4);
+        -gtk-icon-shadow: 0 1px alpha(black, 0.4);
         outline-color: rgba(238, 238, 236, 0.3); }
-      .osd .button.suggested-action:insensitive, .osd .button.suggested-action:backdrop:insensitive {
+      .osd .button.suggested-action:disabled, .osd .button.suggested-action:backdrop:disabled {
         color: shade(@insensitive_fg_color, 1.4);
         border-color: rgba(0, 0, 0, 0.0);
-        background-image: linear-gradient(to bottom, rgba(52, 57, 57, 0.0));
+        background-image: image(rgba(52, 57, 57, 0.0));
         background-clip: padding-box;
         box-shadow: none;
         text-shadow: none;
-        icon-shadow: 0 1px alpha(black, 0.4); }
+        -gtk-icon-shadow: 0 1px alpha(black, 0.4); }
       .osd .button.suggested-action:backdrop {
         color: #eeeeec;
         border-color: rgba(0, 0, 0, 0.7);
-        background-image: linear-gradient(to bottom, rgba(15,15,16, 0.5));
+        background-image: image(rgba(15,15,16, 0.5));
         background-clip: padding-box;
         box-shadow: none;
         text-shadow: none;
-        icon-shadow: none; }
+        -gtk-icon-shadow: none; }
   .button.destructive-action, .header-bar .destructive-action.button.titlebutton,
   .titlebar .destructive-action.button.titlebutton {
     color: white;
@@ -1128,7 +1122,7 @@ color:black;
 				0 -3px alpha(black, 0.01) inset,
 				0 1px alpha(white, 0.08);
     text-shadow: 0 -1px rgba(0, 0, 0, 0.56078);
-    icon-shadow: 0 -1px rgba(0, 0, 0, 0.56078); }
+    -gtk-icon-shadow: 0 -1px rgba(0, 0, 0, 0.56078); }
     .button.destructive-action.flat, .destructive-action.sidebar-button.button, .header-bar .destructive-action.titlebutton.button,
     .titlebar .destructive-action.titlebutton.button {
       border-color: transparent;
@@ -1136,7 +1130,7 @@ color:black;
       background-image: none;
       box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0);
       text-shadow: none;
-      icon-shadow: none;
+      -gtk-icon-shadow: none;
       color: #940000; }
     .button.destructive-action:hover {
       color: white;
@@ -1165,7 +1159,7 @@ color:black;
 				0 -3px alpha(black, 0.01) inset,
 				0 1px 2px 0 alpha(black, 0.2);
       text-shadow: 0 -1px rgba(0, 0, 0, 0.52878);
-      icon-shadow: 0 -1px rgba(0, 0, 0, 0.52878); }
+      -gtk-icon-shadow: 0 -1px rgba(0, 0, 0, 0.52878); }
     .button.destructive-action:active, .button.destructive-action:checked {
       color: white;
       outline-color: rgba(255, 255, 255, 0.3);
@@ -1175,7 +1169,7 @@ color:black;
                                       mix(shade(#940000, 1.2), @theme_selected_bg_color, 0.25));
     background-color: transparent;
       text-shadow: 0 -1px rgba(0, 0, 0, 0.64078);
-      icon-shadow: 0 -1px rgba(0, 0, 0, 0.64078);
+      -gtk-icon-shadow: 0 -1px rgba(0, 0, 0, 0.64078);
       box-shadow: inset 0 1px rgba(0, 0, 0, 0.07), inset 0 2px 1px -2px rgba(0, 0, 0, 0.6), 0 1px alpha(white,0.12); }
     .button.destructive-action:backdrop, .button.destructive-action.flat:backdrop, .destructive-action.sidebar-button.button:backdrop, .header-bar .destructive-action.titlebutton.button:backdrop,
     .titlebar .destructive-action.titlebutton.button:backdrop {
@@ -1203,7 +1197,7 @@ color:black;
 				0 -2px alpha(black, 0.01) inset,
 				0 -3px alpha(black, 0.005) inset; 
       text-shadow: none;
-      icon-shadow: none; }
+      -gtk-icon-shadow: none; }
       .button.destructive-action:backdrop:active, .button.destructive-action:backdrop:checked, .button.destructive-action.flat:backdrop:active, .destructive-action.sidebar-button.button:backdrop:active, .header-bar .destructive-action.titlebutton.button:backdrop:active,
       .titlebar .destructive-action.titlebutton.button:backdrop:active, .button.destructive-action.flat:backdrop:checked, .destructive-action.sidebar-button.button:backdrop:checked, .header-bar .destructive-action.titlebutton.button:backdrop:checked,
       .titlebar .destructive-action.titlebutton.button:backdrop:checked {
@@ -1213,98 +1207,98 @@ color:black;
                                       shade( mix(shade(#940000, 0.9), @theme_selected_bg_color, 0.20), 0.8), 
                                       shade( mix(shade(#940000, 1.2), @theme_selected_bg_color, 0.20), 0.8));
         box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0); }
-      .button.destructive-action:backdrop:insensitive, .button.destructive-action.flat:backdrop:insensitive, .destructive-action.sidebar-button.button:backdrop:insensitive, .header-bar .destructive-action.titlebutton.button:backdrop:insensitive,
-      .titlebar .destructive-action.titlebutton.button:backdrop:insensitive {
+      .button.destructive-action:backdrop:disabled, .button.destructive-action.flat:backdrop:disabled, .destructive-action.sidebar-button.button:backdrop:disabled, .header-bar .destructive-action.titlebutton.button:backdrop:disabled,
+      .titlebar .destructive-action.titlebutton.button:backdrop:disabled {
         color: #4a4a4d;
         border-color: #202022;
-        background-image: linear-gradient(to bottom, #262628);
+        background-image: image(#262628);
         text-shadow: none;
-        icon-shadow: none;
+        -gtk-icon-shadow: none;
         box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0); }
-        .button.destructive-action:backdrop:insensitive > .label, .button.destructive-action.flat:backdrop:insensitive > .label, .destructive-action.sidebar-button.button:backdrop:insensitive > .label, .header-bar .destructive-action.titlebutton.button:backdrop:insensitive > .label,
-        .titlebar .destructive-action.titlebutton.button:backdrop:insensitive > .label {
+        .button.destructive-action:backdrop:disabled > .label, .button.destructive-action.flat:backdrop:disabled > .label, .destructive-action.sidebar-button.button:backdrop:disabled > .label, .header-bar .destructive-action.titlebutton.button:backdrop:disabled > .label,
+        .titlebar .destructive-action.titlebutton.button:backdrop:disabled > .label {
           color: inherit; }
-        .button.destructive-action:backdrop:insensitive:active, .button.destructive-action:backdrop:insensitive:checked, .button.destructive-action.flat:backdrop:insensitive:active, .destructive-action.sidebar-button.button:backdrop:insensitive:active, .header-bar .destructive-action.titlebutton.button:backdrop:insensitive:active,
-        .titlebar .destructive-action.titlebutton.button:backdrop:insensitive:active, .button.destructive-action.flat:backdrop:insensitive:checked, .destructive-action.sidebar-button.button:backdrop:insensitive:checked, .header-bar .destructive-action.titlebutton.button:backdrop:insensitive:checked,
-        .titlebar .destructive-action.titlebutton.button:backdrop:insensitive:checked {
+        .button.destructive-action:backdrop:disabled:active, .button.destructive-action:backdrop:disabled:checked, .button.destructive-action.flat:backdrop:disabled:active, .destructive-action.sidebar-button.button:backdrop:disabled:active, .header-bar .destructive-action.titlebutton.button:backdrop:disabled:active,
+        .titlebar .destructive-action.titlebutton.button:backdrop:disabled:active, .button.destructive-action.flat:backdrop:disabled:checked, .destructive-action.sidebar-button.button:backdrop:disabled:checked, .header-bar .destructive-action.titlebutton.button:backdrop:disabled:checked,
+        .titlebar .destructive-action.titlebutton.button:backdrop:disabled:checked {
           color: #7a7a7d;
       border-color: #202022;
-      background-image: linear-gradient(to bottom, #2a2a2c);
+      background-image: image(#2a2a2c);
           box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0); }
-          .button.destructive-action:backdrop:insensitive:active > .label, .button.destructive-action:backdrop:insensitive:checked > .label, .button.destructive-action.flat:backdrop:insensitive:active > .label, .destructive-action.sidebar-button.button:backdrop:insensitive:active > .label, .header-bar .destructive-action.titlebutton.button:backdrop:insensitive:active > .label,
-          .titlebar .destructive-action.titlebutton.button:backdrop:insensitive:active > .label, .button.destructive-action.flat:backdrop:insensitive:checked > .label, .destructive-action.sidebar-button.button:backdrop:insensitive:checked > .label, .header-bar .destructive-action.titlebutton.button:backdrop:insensitive:checked > .label,
-          .titlebar .destructive-action.titlebutton.button:backdrop:insensitive:checked > .label {
+          .button.destructive-action:backdrop:disabled:active > .label, .button.destructive-action:backdrop:disabled:checked > .label, .button.destructive-action.flat:backdrop:disabled:active > .label, .destructive-action.sidebar-button.button:backdrop:disabled:active > .label, .header-bar .destructive-action.titlebutton.button:backdrop:disabled:active > .label,
+          .titlebar .destructive-action.titlebutton.button:backdrop:disabled:active > .label, .button.destructive-action.flat:backdrop:disabled:checked > .label, .destructive-action.sidebar-button.button:backdrop:disabled:checked > .label, .header-bar .destructive-action.titlebutton.button:backdrop:disabled:checked > .label,
+          .titlebar .destructive-action.titlebutton.button:backdrop:disabled:checked > .label {
             color: inherit; }
     .button.destructive-action.flat:backdrop, .destructive-action.sidebar-button.button:backdrop, .header-bar .destructive-action.titlebutton.button:backdrop,
-    .titlebar .destructive-action.titlebutton.button:backdrop, .button.destructive-action.flat:insensitive, .destructive-action.sidebar-button.button:insensitive, .header-bar .destructive-action.titlebutton.button:insensitive,
-    .titlebar .destructive-action.titlebutton.button:insensitive, .button.destructive-action.flat:backdrop:insensitive, .destructive-action.sidebar-button.button:backdrop:insensitive, .header-bar .destructive-action.titlebutton.button:backdrop:insensitive,
-    .titlebar .destructive-action.titlebutton.button:backdrop:insensitive {
+    .titlebar .destructive-action.titlebutton.button:backdrop, .button.destructive-action.flat:disabled, .destructive-action.sidebar-button.button:disabled, .header-bar .destructive-action.titlebutton.button:disabled,
+    .titlebar .destructive-action.titlebutton.button:disabled, .button.destructive-action.flat:backdrop:disabled, .destructive-action.sidebar-button.button:backdrop:disabled, .header-bar .destructive-action.titlebutton.button:backdrop:disabled,
+    .titlebar .destructive-action.titlebutton.button:backdrop:disabled {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
       box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0);
       text-shadow: none;
-      icon-shadow: none;
+      -gtk-icon-shadow: none;
       color: rgba(239, 41, 41, 0.8); }
-    .button.destructive-action:insensitive {
+    .button.destructive-action:disabled {
       color: @insensitive_fg_color;
     border-color: #1c1c1f;
-    background-image: linear-gradient(to bottom, #2c2c2e);
+    background-image: image(#2c2c2e);
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px alpha(white,0.08); }
-      .button.destructive-action:insensitive > .label {
+      .button.destructive-action:disabled > .label {
         color: inherit; }
-      .button.destructive-action:insensitive:active, .button.destructive-action:insensitive:checked {
+      .button.destructive-action:disabled:active, .button.destructive-action:disabled:checked {
         color: @insensitive_fg_color;
       border-color: #1c1c1f;
       background-image: linear-gradient(to bottom, #242426, #2c2c2e);
       box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px alpha(white,0.08); }
-        .button.destructive-action:insensitive:active > .label, .button.destructive-action:insensitive:checked > .label {
+        .button.destructive-action:disabled:active > .label, .button.destructive-action:disabled:checked > .label {
           color: inherit; }
     .osd .button.destructive-action {
       color: #eeeeec;
       border-color: rgba(0, 0, 0, 0.7);
-      background-image: linear-gradient(to bottom, alpha(#940000,0.5));
+      background-image: image(alpha(#940000,0.5));
       background-clip: padding-box;
       box-shadow: inset 0 1px rgba(255, 255, 255, 0.1);
       text-shadow: 0 1px black;
-      icon-shadow: 0 1px black;
+      -gtk-icon-shadow: 0 1px black;
       outline-color: rgba(238, 238, 236, 0.3); }
       .osd .button.destructive-action:hover {
         color: white;
         border-color: rgba(0, 0, 0, 0.7);
-        background-image: linear-gradient(to bottom, alpha(#940000,0.7));
+        background-image: image(alpha(#940000,0.7));
         background-clip: padding-box;
         box-shadow: inset 0 1px rgba(255, 255, 255, 0.1);
         text-shadow: 0 1px black;
-        icon-shadow: 0 1px black;
+        -gtk-icon-shadow: 0 1px black;
         outline-color: rgba(238, 238, 236, 0.3); }
       .osd .button.destructive-action:active, .osd .button.destructive-action:checked, .osd .button.destructive-action:backdrop:active, .osd .button.destructive-action:backdrop:checked {
         color: white;
         border-color: rgba(0, 0, 0, 0.7);
-        background-image: linear-gradient(to bottom, #450000);
+        background-image: image(#450000);
         background-clip: padding-box;
         box-shadow: none;
         text-shadow: none;
-        icon-shadow: none;
+        -gtk-icon-shadow: none;
         outline-color: rgba(238, 238, 236, 0.3); }
-      .osd .button.destructive-action:insensitive, .osd .button.destructive-action:backdrop:insensitive {
+      .osd .button.destructive-action:disabled, .osd .button.destructive-action:backdrop:disabled {
         color: shade(@insensitive_fg_color, 1.4);
         border-color: transparent;
-        background-image: linear-gradient(to bottom, rgba(52, 57, 57, 0.0));
+        background-image: image(rgba(52, 57, 57, 0.0));
         background-clip: padding-box;
         box-shadow: none;
         text-shadow: none;
-        icon-shadow: 0 1px alpha(black,0.4); }
+        -gtk-icon-shadow: 0 1px alpha(black,0.4); }
       .osd .button.destructive-action:backdrop {
         color: #eeeeec;
         border-color: rgba(0, 0, 0, 0.7);
-        background-image: linear-gradient(to bottom, alpha(#940000,0.5));
+        background-image: image(alpha(#940000,0.5));
         background-clip: padding-box;
         box-shadow: none;
         text-shadow: none;
-        icon-shadow: none; }
+        -gtk-icon-shadow: none; }
   .button.image-button, GtkScaleButton.button,
   GtkVolumeButton.button, .header-bar .titlebutton.button,
   .titlebar .titlebutton.button {
@@ -1355,7 +1349,7 @@ color:black;
   .primary-toolbar .button, .primary-toolbar .header-bar .button.titlebutton, .header-bar .primary-toolbar .button.titlebutton,
   .primary-toolbar .titlebar .button.titlebutton,
   .titlebar .primary-toolbar .button.titlebutton {
-    icon-shadow: none; }
+    -gtk-icon-shadow: none; }
 
 .stack-switcher > .button.needs-attention > .label, .stack-switcher > .button.needs-attention > GtkImage, .sidebar-item.needs-attention > .label {
   animation: needs_attention 150ms ease-in;
@@ -1387,7 +1381,7 @@ color:black;
 									  #040404
 									  ); 
   text-shadow: 0 1px rgba(0,0,0, 0.76923);
-  icon-shadow: 0 1px rgba(0,0,0, 0.76923);
+  -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923);
   box-shadow: inset 0 1px alpha(white,0.14), 0 1px alpha(white,0.08); }
   .inline-toolbar GtkToolButton > .button:hover,
   .inline-toolbar GtkButton.button:hover {
@@ -1406,7 +1400,7 @@ color:black;
 									  #020202
 									  );
     text-shadow: 0 1px rgba(0,0,0, 0.76923);
-    icon-shadow: 0 1px rgba(0,0,0, 0.76923);
+    -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923);
     box-shadow: inset 1px 0 alpha(white, 0.03),
 				inset -1px 0 alpha(black, 0.86); }
   .inline-toolbar GtkToolButton > .button:active, .inline-toolbar GtkToolButton > .button:checked,
@@ -1426,10 +1420,10 @@ color:black;
 									  #030303
 									  );
     text-shadow: 0 1px rgba(0,0,0, 0.76923);
-    icon-shadow: 0 1px rgba(0,0,0, 0.76923);
+    -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923);
     box-shadow: inset 0 1px rgba(0, 0, 0, 0.07), inset 0 2px 1px -2px rgba(0, 0, 0, 0.6), 0 1px alpha(white,0.12); }
-  .inline-toolbar GtkToolButton > .button:insensitive,
-  .inline-toolbar GtkButton.button:insensitive {
+  .inline-toolbar GtkToolButton > .button:disabled,
+  .inline-toolbar GtkButton.button:disabled {
     color: @insensitive_fg_color;
     border-color: #000;
     background-image: linear-gradient(to bottom, 
@@ -1443,13 +1437,13 @@ color:black;
 									  #040404
 									  );
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px alpha(white,0.08); }
-    .inline-toolbar GtkToolButton > .button:insensitive > .label,
-    .inline-toolbar GtkButton.button:insensitive > .label {
+    .inline-toolbar GtkToolButton > .button:disabled > .label,
+    .inline-toolbar GtkButton.button:disabled > .label {
       color: inherit; }
-  .inline-toolbar GtkToolButton > .button:insensitive:active, .inline-toolbar GtkToolButton > .button:insensitive:checked,
-  .inline-toolbar GtkButton.button:insensitive:active, .inline-toolbar GtkButton.button:insensitive:checked {
+  .inline-toolbar GtkToolButton > .button:disabled:active, .inline-toolbar GtkToolButton > .button:disabled:checked,
+  .inline-toolbar GtkButton.button:disabled:active, .inline-toolbar GtkButton.button:disabled:checked {
     color: @insensitive_fg_color;
     border-color: #000;
     background-color: transparent;
@@ -1464,8 +1458,8 @@ color:black;
 									  #030303
 									  );
     box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px alpha(white,0.08); }
-    .inline-toolbar GtkToolButton > .button:insensitive:active > .label, .inline-toolbar GtkToolButton > .button:insensitive:checked > .label,
-    .inline-toolbar GtkButton.button:insensitive:active > .label, .inline-toolbar GtkButton.button:insensitive:checked > .label {
+    .inline-toolbar GtkToolButton > .button:disabled:active > .label, .inline-toolbar GtkToolButton > .button:disabled:checked > .label,
+    .inline-toolbar GtkButton.button:disabled:active > .label, .inline-toolbar GtkButton.button:disabled:checked > .label {
       color: inherit; }
   .inline-toolbar GtkToolButton > .button:backdrop,
   .inline-toolbar GtkButton.button:backdrop {
@@ -1482,7 +1476,7 @@ color:black;
 									  #030303
 									  );
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0); }
   .inline-toolbar GtkToolButton > .button:backdrop:active, .inline-toolbar GtkToolButton > .button:backdrop:checked,
   .inline-toolbar GtkButton.button:backdrop:active, .inline-toolbar GtkButton.button:backdrop:checked {
@@ -1500,8 +1494,8 @@ color:black;
 									  #020202
 									  );
     box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0); }
-  .inline-toolbar GtkToolButton > .button:backdrop:insensitive,
-  .inline-toolbar GtkButton.button:backdrop:insensitive {
+  .inline-toolbar GtkToolButton > .button:backdrop:disabled,
+  .inline-toolbar GtkButton.button:backdrop:disabled {
     color: #4a4a4d;
     border-color: #000;
     background-image: linear-gradient(to bottom, 
@@ -1515,13 +1509,13 @@ color:black;
 									  shade(#040404, 0.8)
 									  );
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0); }
-    .inline-toolbar GtkToolButton > .button:backdrop:insensitive > .label,
-    .inline-toolbar GtkButton.button:backdrop:insensitive > .label {
+    .inline-toolbar GtkToolButton > .button:backdrop:disabled > .label,
+    .inline-toolbar GtkButton.button:backdrop:disabled > .label {
       color: inherit; }
-  .inline-toolbar GtkToolButton > .button:backdrop:insensitive:active, .inline-toolbar GtkToolButton > .button:backdrop:insensitive:checked,
-  .inline-toolbar GtkButton.button:backdrop:insensitive:active, .inline-toolbar GtkButton.button:backdrop:insensitive:checked {
+  .inline-toolbar GtkToolButton > .button:backdrop:disabled:active, .inline-toolbar GtkToolButton > .button:backdrop:disabled:checked,
+  .inline-toolbar GtkButton.button:backdrop:disabled:active, .inline-toolbar GtkButton.button:backdrop:disabled:checked {
     color: #7a7a7d;
     border-color: #000;
     background-color: transparent;
@@ -1536,8 +1530,8 @@ color:black;
 									  #020202
 									  );
     box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0); }
-    .inline-toolbar GtkToolButton > .button:backdrop:insensitive:active > .label, .inline-toolbar GtkToolButton > .button:backdrop:insensitive:checked > .label,
-    .inline-toolbar GtkButton.button:backdrop:insensitive:active > .label, .inline-toolbar GtkButton.button:backdrop:insensitive:checked > .label {
+    .inline-toolbar GtkToolButton > .button:backdrop:disabled:active > .label, .inline-toolbar GtkToolButton > .button:backdrop:disabled:checked > .label,
+    .inline-toolbar GtkButton.button:backdrop:disabled:active > .label, .inline-toolbar GtkButton.button:backdrop:disabled:checked > .label {
       color: inherit; }
 
 .inline-toolbar.toolbar GtkToolButton > .button.flat, .inline-toolbar GtkToolButton > .button.flat, .inline-toolbar.search-bar GtkToolButton > .button.flat, .inline-toolbar.location-bar GtkToolButton > .button.flat, .inline-toolbar.toolbar GtkToolButton > .sidebar-button.button, .inline-toolbar GtkToolButton > .sidebar-button.button, .inline-toolbar.search-bar GtkToolButton > .sidebar-button.button, .inline-toolbar.location-bar GtkToolButton > .sidebar-button.button, .inline-toolbar .header-bar GtkToolButton > .button.titlebutton, .header-bar .inline-toolbar GtkToolButton > .button.titlebutton,
@@ -1554,7 +1548,7 @@ color:black;
 .inline-toolbar .header-bar GtkToolButton:backdrop > .button.titlebutton,
 .header-bar .inline-toolbar GtkToolButton:backdrop > .button.titlebutton,
 .inline-toolbar .titlebar GtkToolButton:backdrop > .button.titlebutton,
-.titlebar .inline-toolbar GtkToolButton:backdrop > .button.titlebutton, .linked:not(.vertical) > .entry, .osd .button:hover, .osd .button:active, .osd .button:checked, .osd .button:backdrop:active, .osd .button:backdrop:checked, .osd .button:insensitive, .osd .button:backdrop:insensitive, .osd .button:backdrop, .osd .button.suggested-action, .osd .button.suggested-action:hover, .osd .button.suggested-action:active, .osd .button.suggested-action:checked, .osd .button.suggested-action:backdrop:active, .osd .button.suggested-action:backdrop:checked, .osd .button.suggested-action:insensitive, .osd .button.suggested-action:backdrop:insensitive, .osd .button.suggested-action:backdrop, .osd .button.destructive-action, .osd .button.destructive-action:hover, .osd .button.destructive-action:active, .osd .button.destructive-action:checked, .osd .button.destructive-action:backdrop:active, .osd .button.destructive-action:backdrop:checked, .osd .button.destructive-action:insensitive, .osd .button.destructive-action:backdrop:insensitive, .osd .button.destructive-action:backdrop, .inline-toolbar .button, .inline-toolbar .header-bar .button.titlebutton, .header-bar .inline-toolbar .button.titlebutton,
+.titlebar .inline-toolbar GtkToolButton:backdrop > .button.titlebutton, .linked:not(.vertical) > .entry, .osd .button:hover, .osd .button:active, .osd .button:checked, .osd .button:backdrop:active, .osd .button:backdrop:checked, .osd .button:disabled, .osd .button:backdrop:disabled, .osd .button:backdrop, .osd .button.suggested-action, .osd .button.suggested-action:hover, .osd .button.suggested-action:active, .osd .button.suggested-action:checked, .osd .button.suggested-action:backdrop:active, .osd .button.suggested-action:backdrop:checked, .osd .button.suggested-action:disabled, .osd .button.suggested-action:backdrop:disabled, .osd .button.suggested-action:backdrop, .osd .button.destructive-action, .osd .button.destructive-action:hover, .osd .button.destructive-action:active, .osd .button.destructive-action:checked, .osd .button.destructive-action:backdrop:active, .osd .button.destructive-action:backdrop:checked, .osd .button.destructive-action:disabled, .osd .button.destructive-action:backdrop:disabled, .osd .button.destructive-action:backdrop, .inline-toolbar .button, .inline-toolbar .header-bar .button.titlebutton, .header-bar .inline-toolbar .button.titlebutton,
 .inline-toolbar .titlebar .button.titlebutton,
 .titlebar .inline-toolbar .button.titlebutton, .inline-toolbar .button:backdrop, .linked > .button, .header-bar .linked > .button.titlebutton,
 .titlebar .linked > .button.titlebutton, .linked > .button:hover, .linked > .button:active, .linked > .button:checked, .linked > .button:backdrop, .linked > GtkComboBox > .the-button-in-the-combobox:dir(ltr), .linked > GtkComboBox > .the-button-in-the-combobox:dir(rtl),
@@ -1563,7 +1557,7 @@ color:black;
   border-radius: 0;
   border-right-style: none; }
 
-.linked:not(.vertical) > .entry:first-child, .osd .button:first-child:hover, .osd .button:first-child:active, .osd .button:first-child:checked, .osd .button:first-child:insensitive, .osd .button:first-child:backdrop, .osd .button.suggested-action:first-child, .osd .button.destructive-action:first-child, .inline-toolbar .button:first-child, .linked > .button:first-child, .inline-toolbar.toolbar GtkToolButton:first-child > .button.flat, .inline-toolbar GtkToolButton:first-child > .button.flat, .inline-toolbar.search-bar GtkToolButton:first-child > .button.flat, .inline-toolbar.location-bar GtkToolButton:first-child > .button.flat, .inline-toolbar.toolbar GtkToolButton:first-child > .sidebar-button.button, .inline-toolbar GtkToolButton:first-child > .sidebar-button.button, .inline-toolbar.search-bar GtkToolButton:first-child > .sidebar-button.button, .inline-toolbar.location-bar GtkToolButton:first-child > .sidebar-button.button, .inline-toolbar .header-bar GtkToolButton:first-child > .button.titlebutton, .header-bar .inline-toolbar GtkToolButton:first-child > .button.titlebutton,
+.linked:not(.vertical) > .entry:first-child, .osd .button:first-child:hover, .osd .button:first-child:active, .osd .button:first-child:checked, .osd .button:first-child:disabled, .osd .button:first-child:backdrop, .osd .button.suggested-action:first-child, .osd .button.destructive-action:first-child, .inline-toolbar .button:first-child, .linked > .button:first-child, .inline-toolbar.toolbar GtkToolButton:first-child > .button.flat, .inline-toolbar GtkToolButton:first-child > .button.flat, .inline-toolbar.search-bar GtkToolButton:first-child > .button.flat, .inline-toolbar.location-bar GtkToolButton:first-child > .button.flat, .inline-toolbar.toolbar GtkToolButton:first-child > .sidebar-button.button, .inline-toolbar GtkToolButton:first-child > .sidebar-button.button, .inline-toolbar.search-bar GtkToolButton:first-child > .sidebar-button.button, .inline-toolbar.location-bar GtkToolButton:first-child > .sidebar-button.button, .inline-toolbar .header-bar GtkToolButton:first-child > .button.titlebutton, .header-bar .inline-toolbar GtkToolButton:first-child > .button.titlebutton,
 .inline-toolbar .titlebar GtkToolButton:first-child > .button.titlebutton,
 .titlebar .inline-toolbar GtkToolButton:first-child > .button.titlebutton,
 .inline-toolbar.toolbar GtkToolButton:backdrop:first-child > .button.flat,
@@ -1581,7 +1575,7 @@ color:black;
 .linked > GtkComboBoxText:first-child > .the-button-in-the-combobox {
   border-top-left-radius: 3px;
   border-bottom-left-radius: 3px; }
-.linked:not(.vertical) > .entry:last-child, .osd .button:last-child:hover, .osd .button:last-child:active, .osd .button:last-child:checked, .osd .button:last-child:insensitive, .osd .button:last-child:backdrop, .osd .button.suggested-action:last-child, .osd .button.destructive-action:last-child, .inline-toolbar .button:last-child, .linked > .button:last-child, .inline-toolbar.toolbar GtkToolButton:last-child > .button.flat, .inline-toolbar GtkToolButton:last-child > .button.flat, .inline-toolbar.search-bar GtkToolButton:last-child > .button.flat, .inline-toolbar.location-bar GtkToolButton:last-child > .button.flat, .inline-toolbar.toolbar GtkToolButton:last-child > .sidebar-button.button, .inline-toolbar GtkToolButton:last-child > .sidebar-button.button, .inline-toolbar.search-bar GtkToolButton:last-child > .sidebar-button.button, .inline-toolbar.location-bar GtkToolButton:last-child > .sidebar-button.button, .inline-toolbar .header-bar GtkToolButton:last-child > .button.titlebutton, .header-bar .inline-toolbar GtkToolButton:last-child > .button.titlebutton,
+.linked:not(.vertical) > .entry:last-child, .osd .button:last-child:hover, .osd .button:last-child:active, .osd .button:last-child:checked, .osd .button:last-child:disabled, .osd .button:last-child:backdrop, .osd .button.suggested-action:last-child, .osd .button.destructive-action:last-child, .inline-toolbar .button:last-child, .linked > .button:last-child, .inline-toolbar.toolbar GtkToolButton:last-child > .button.flat, .inline-toolbar GtkToolButton:last-child > .button.flat, .inline-toolbar.search-bar GtkToolButton:last-child > .button.flat, .inline-toolbar.location-bar GtkToolButton:last-child > .button.flat, .inline-toolbar.toolbar GtkToolButton:last-child > .sidebar-button.button, .inline-toolbar GtkToolButton:last-child > .sidebar-button.button, .inline-toolbar.search-bar GtkToolButton:last-child > .sidebar-button.button, .inline-toolbar.location-bar GtkToolButton:last-child > .sidebar-button.button, .inline-toolbar .header-bar GtkToolButton:last-child > .button.titlebutton, .header-bar .inline-toolbar GtkToolButton:last-child > .button.titlebutton,
 .inline-toolbar .titlebar GtkToolButton:last-child > .button.titlebutton,
 .titlebar .inline-toolbar GtkToolButton:last-child > .button.titlebutton,
 .inline-toolbar.toolbar GtkToolButton:backdrop:last-child > .button.flat,
@@ -1600,7 +1594,7 @@ color:black;
   border-top-right-radius: 3px;
   border-bottom-right-radius: 3px;
   border-right-style: solid; }
-.linked:not(.vertical) > .entry:only-child, .osd .button:only-child:hover, .osd .button:only-child:active, .osd .button:only-child:checked, .osd .button:only-child:insensitive, .osd .button:only-child:backdrop, .osd .button.suggested-action:only-child, .osd .button.destructive-action:only-child, .inline-toolbar .button:only-child, .linked > .button:only-child, .inline-toolbar.toolbar GtkToolButton:only-child > .button.flat, .inline-toolbar GtkToolButton:only-child > .button.flat, .inline-toolbar.search-bar GtkToolButton:only-child > .button.flat, .inline-toolbar.location-bar GtkToolButton:only-child > .button.flat, .inline-toolbar.toolbar GtkToolButton:only-child > .sidebar-button.button, .inline-toolbar GtkToolButton:only-child > .sidebar-button.button, .inline-toolbar.search-bar GtkToolButton:only-child > .sidebar-button.button, .inline-toolbar.location-bar GtkToolButton:only-child > .sidebar-button.button, .inline-toolbar .header-bar GtkToolButton:only-child > .button.titlebutton, .header-bar .inline-toolbar GtkToolButton:only-child > .button.titlebutton,
+.linked:not(.vertical) > .entry:only-child, .osd .button:only-child:hover, .osd .button:only-child:active, .osd .button:only-child:checked, .osd .button:only-child:disabled, .osd .button:only-child:backdrop, .osd .button.suggested-action:only-child, .osd .button.destructive-action:only-child, .inline-toolbar .button:only-child, .linked > .button:only-child, .inline-toolbar.toolbar GtkToolButton:only-child > .button.flat, .inline-toolbar GtkToolButton:only-child > .button.flat, .inline-toolbar.search-bar GtkToolButton:only-child > .button.flat, .inline-toolbar.location-bar GtkToolButton:only-child > .button.flat, .inline-toolbar.toolbar GtkToolButton:only-child > .sidebar-button.button, .inline-toolbar GtkToolButton:only-child > .sidebar-button.button, .inline-toolbar.search-bar GtkToolButton:only-child > .sidebar-button.button, .inline-toolbar.location-bar GtkToolButton:only-child > .sidebar-button.button, .inline-toolbar .header-bar GtkToolButton:only-child > .button.titlebutton, .header-bar .inline-toolbar GtkToolButton:only-child > .button.titlebutton,
 .inline-toolbar .titlebar GtkToolButton:only-child > .button.titlebutton,
 .titlebar .inline-toolbar GtkToolButton:only-child > .button.titlebutton,
 .inline-toolbar.toolbar GtkToolButton:backdrop:only-child > .button.flat,
@@ -1649,30 +1643,30 @@ color:black;
 .app-notification .titlebar .titlebutton.button,
 .titlebar .app-notification .titlebutton.button,
 .app-notification.frame .button.flat,
-.app-notification.frame .sidebar-button.button, .app-notification .button.flat:backdrop, .app-notification .sidebar-button.button:backdrop, .app-notification .button.flat:insensitive, .app-notification .sidebar-button.button:insensitive, .app-notification .button.flat:backdrop:insensitive, .app-notification .sidebar-button.button:backdrop:insensitive, .app-notification .header-bar .titlebutton.button:backdrop:insensitive, .header-bar .app-notification .titlebutton.button:backdrop:insensitive,
-.app-notification .titlebar .titlebutton.button:backdrop:insensitive,
-.titlebar .app-notification .titlebutton.button:backdrop:insensitive,
+.app-notification.frame .sidebar-button.button, .app-notification .button.flat:backdrop, .app-notification .sidebar-button.button:backdrop, .app-notification .button.flat:disabled, .app-notification .sidebar-button.button:disabled, .app-notification .button.flat:backdrop:disabled, .app-notification .sidebar-button.button:backdrop:disabled, .app-notification .header-bar .titlebutton.button:backdrop:disabled, .header-bar .app-notification .titlebutton.button:backdrop:disabled,
+.app-notification .titlebar .titlebutton.button:backdrop:disabled,
+.titlebar .app-notification .titlebutton.button:backdrop:disabled,
 .app-notification.frame .button.flat:backdrop,
 .app-notification.frame .sidebar-button.button:backdrop,
 .app-notification.frame .header-bar .button.titlebutton:backdrop,
 .header-bar .app-notification.frame .button.titlebutton:backdrop,
 .app-notification.frame .titlebar .button.titlebutton:backdrop,
 .titlebar .app-notification.frame .button.titlebutton:backdrop,
-.app-notification.frame .button.flat:insensitive,
-.app-notification.frame .sidebar-button.button:insensitive,
-.app-notification.frame .header-bar .button.titlebutton:insensitive,
-.header-bar .app-notification.frame .button.titlebutton:insensitive,
-.app-notification.frame .titlebar .button.titlebutton:insensitive,
-.titlebar .app-notification.frame .button.titlebutton:insensitive,
-.app-notification.frame .button.flat:backdrop:insensitive,
-.app-notification.frame .sidebar-button.button:backdrop:insensitive, GtkCalendar.button, .header-bar GtkCalendar.button.titlebutton,
-.titlebar GtkCalendar.button.titlebutton, GtkCalendar.button:hover, GtkCalendar.button:backdrop, GtkCalendar.button:insensitive, .scale-popup .button:hover, .scale-popup .button:backdrop, .scale-popup .button:backdrop:hover, .scale-popup .button:backdrop:insensitive {
+.app-notification.frame .button.flat:disabled,
+.app-notification.frame .sidebar-button.button:disabled,
+.app-notification.frame .header-bar .button.titlebutton:disabled,
+.header-bar .app-notification.frame .button.titlebutton:disabled,
+.app-notification.frame .titlebar .button.titlebutton:disabled,
+.titlebar .app-notification.frame .button.titlebutton:disabled,
+.app-notification.frame .button.flat:backdrop:disabled,
+.app-notification.frame .sidebar-button.button:backdrop:disabled, GtkCalendar.button, .header-bar GtkCalendar.button.titlebutton,
+.titlebar GtkCalendar.button.titlebutton, GtkCalendar.button:hover, GtkCalendar.button:backdrop, GtkCalendar.button:disabled, .scale-popup .button:hover, .scale-popup .button:backdrop, .scale-popup .button:backdrop:hover, .scale-popup .button:backdrop:disabled {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
   box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0);
   text-shadow: none;
-  icon-shadow: none; }
+  -gtk-icon-shadow: none; }
 
 /* menu buttons */
 .menuitem.button.flat, .menuitem.sidebar-button.button, .header-bar .menuitem.titlebutton.button,
@@ -1688,7 +1682,7 @@ GtkColorButton.button, .header-bar GtkColorButton.button.titlebutton,
   GtkColorButton.button GtkColorSwatch:first-child:last-child {
     border-radius: 0;
     box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.1), 0 1px alpha(white,0.08); }
-    GtkColorButton.button GtkColorSwatch:first-child:last-child:insensitive, GtkColorButton.button GtkColorSwatch:first-child:last-child:backdrop {
+    GtkColorButton.button GtkColorSwatch:first-child:last-child:disabled, GtkColorButton.button GtkColorSwatch:first-child:last-child:backdrop {
       box-shadow: none; }
 
 /*********
@@ -1744,24 +1738,24 @@ GtkColorButton.button, .header-bar GtkColorButton.button.titlebutton,
   .spinbutton .button:hover {
     color: black;
     background-color: rgba(46, 52, 54, 0.05);
-    icon-shadow: 0 1px rgba(255,255,255,0.4); }
-  .spinbutton .button:insensitive {
+    -gtk-icon-shadow: 0 1px rgba(255,255,255,0.4); }
+  .spinbutton .button:disabled {
     color: shade(@insensitive_fg_color,1.3); }
   .spinbutton .button:active {
   color: black;
     box-shadow: inset 0 2px 3px -1px rgba(0, 0, 0, 0.2);
     background-color: rgba(0, 0, 0, 0.3);
-    icon-shadow: 0 1px rgba(255,255,255,0.4); }
+    -gtk-icon-shadow: 0 1px rgba(255,255,255,0.4); }
   .spinbutton .button:backdrop {
     color: @theme_unfocused_fg_color;
     border-color: @theme_unfocused_fg_color;
     background-color: transparent; }
-  .spinbutton .button:backdrop:insensitive {
+  .spinbutton .button:backdrop:disabled {
     background-image: none;
     color: #4a4a4d;
     border-color: rgba(199, 199, 199, 0.2);
     border-style: none none none solid; }
-    .spinbutton .button:backdrop:insensitive:dir(rtl) {
+    .spinbutton .button:backdrop:disabled:dir(rtl) {
       border-style: none solid none none; }
 .osd .spinbutton .button {
   border-color: transparent;
@@ -1769,13 +1763,13 @@ GtkColorButton.button, .header-bar GtkColorButton.button.titlebutton,
   background-image: none;
   box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0);
   text-shadow: none;
-  icon-shadow: none;
+  -gtk-icon-shadow: none;
   color: #eeeeec;
   border-style: none none none solid;
   border-color: rgba(0, 0, 0, 0.4);
   border-radius: 0;
   box-shadow: none;
-  icon-shadow: 0 1px black; }
+  -gtk-icon-shadow: 0 1px black; }
   .osd .spinbutton .button:dir(rtl) {
     border-style: none solid none none; }
   .osd .spinbutton .button:hover {
@@ -1784,11 +1778,11 @@ GtkColorButton.button, .header-bar GtkColorButton.button.titlebutton,
     background-image: none;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0);
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     color: #eeeeec;
     border-color: rgba(0, 0, 0, 0.5);
     background-color: rgba(238, 238, 236, 0.1);
-    icon-shadow: 0 1px black;
+    -gtk-icon-shadow: 0 1px black;
     box-shadow: none; }
   .osd .spinbutton .button:backdrop {
     border-color: transparent;
@@ -1796,21 +1790,21 @@ GtkColorButton.button, .header-bar GtkColorButton.button.titlebutton,
     background-image: none;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0);
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     color: #eeeeec;
     border-color: rgba(0, 0, 0, 0.5);
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     box-shadow: none; }
-  .osd .spinbutton .button:insensitive {
+  .osd .spinbutton .button:disabled {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0);
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     color: @insesnitive_fg_color;
     border-color: rgba(0, 0, 0, 0.5);
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     box-shadow: none; }
   .osd .spinbutton .button:last-child {
     border-radius: 0 3px 3px 0; }
@@ -1838,7 +1832,7 @@ GtkColorButton.button, .header-bar GtkColorButton.button.titlebutton,
                                       shade(#3c3c3e, 0.9)
                                       );     
   text-shadow: 0 -1px rgba(0,0,0,0.7);
-  icon-shadow: 0 -1px rgba(0,0,0,0.7);                                   
+  -gtk-icon-shadow: 0 -1px rgba(0,0,0,0.7);                                   
   box-shadow: 0 1px alpha(white, 0.08) inset,
 				0 2px alpha(white, 0.04) inset,
 				1px 0 alpha(white, 0.03) inset,
@@ -1857,7 +1851,7 @@ GtkColorButton.button, .header-bar GtkColorButton.button.titlebutton,
                                       mix(shade(#3c3c3e, 1.2), @theme_selected_bg_color, 0.25));
     background-color: transparent;
     text-shadow: 0 1px rgba(0,0,0, 0.76923);
-    icon-shadow: 0 1px rgba(0,0,0, 0.76923);
+    -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923);
     box-shadow: inset 0 1px rgba(0, 0, 0, 0.07), inset 0 2px 1px -2px rgba(0, 0, 0, 0.6), 0 1px alpha(white,0.12); }
     .spinbutton.vertical .button:first-child:hover, .spinbutton.vertical:dir(rtl) .button:first-child:hover {
       color: shade(@theme_fg_color, 1.2);
@@ -1885,15 +1879,15 @@ GtkColorButton.button, .header-bar GtkColorButton.button.titlebutton,
 				0 -3px alpha(black, 0.01) inset,
 				0 1px 2px 0 rgba(0,0,0,0.2); 
     text-shadow: 0 1px rgba(0,0,0, 0.76923);
-    icon-shadow: 0 1px rgba(0,0,0, 0.76923); }
-    .spinbutton.vertical .button:first-child:insensitive, .spinbutton.vertical:dir(rtl) .button:first-child:insensitive {
+    -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923); }
+    .spinbutton.vertical .button:first-child:disabled, .spinbutton.vertical:dir(rtl) .button:first-child:disabled {
       color: @insensitive_fg_color;
       border-color: #1c1c1f;
-    background-image: linear-gradient(to bottom, #2c2c2e);
+    background-image: image(#2c2c2e);
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px alpha(white,0.08); }
-      .spinbutton.vertical .button:first-child:insensitive > .label, .spinbutton.vertical:dir(rtl) .button:first-child:insensitive > .label {
+      .spinbutton.vertical .button:first-child:disabled > .label, .spinbutton.vertical:dir(rtl) .button:first-child:disabled > .label {
         color: inherit; }
     .spinbutton.vertical .button:first-child:backdrop, .spinbutton.vertical:dir(rtl) .button:first-child:backdrop {
       color: @theme_unfocused_fg_color;
@@ -1938,7 +1932,7 @@ GtkColorButton.button, .header-bar GtkColorButton.button.titlebutton,
                                       shade(#3c3c3e, 0.9)
                                       );     
   text-shadow: 0 -1px rgba(0,0,0,0.7);
-  icon-shadow: 0 -1px rgba(0,0,0,0.7);
+  -gtk-icon-shadow: 0 -1px rgba(0,0,0,0.7);
     box-shadow: 0 1px alpha(white, 0.08) inset,
 				0 2px alpha(white, 0.04) inset,
 				1px 0 alpha(white, 0.03) inset,
@@ -1957,7 +1951,7 @@ GtkColorButton.button, .header-bar GtkColorButton.button.titlebutton,
                                       mix(shade(#3c3c3e, 1.2), @theme_selected_bg_color, 0.25));
     background-color: transparent;
     text-shadow: 0 1px rgba(0,0,0, 0.76923);
-    icon-shadow: 0 1px rgba(0,0,0, 0.76923);
+    -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923);
     box-shadow: inset 0 1px rgba(0, 0, 0, 0.07), inset 0 2px 1px -2px rgba(0, 0, 0, 0.6), 0 1px alpha(white,0.12); }
     .spinbutton.vertical .button:last-child:hover, .spinbutton.vertical:dir(rtl) .button:last-child:hover {
       color: shade(@theme_fg_color, 1.2);
@@ -1985,15 +1979,15 @@ GtkColorButton.button, .header-bar GtkColorButton.button.titlebutton,
 				0 -3px alpha(black, 0.01) inset,
 				0 1px 2px 0 rgba(0,0,0,0.2); 
     text-shadow: 0 1px rgba(0,0,0, 0.76923);
-    icon-shadow: 0 1px rgba(0,0,0, 0.76923); }
-    .spinbutton.vertical .button:last-child:insensitive, .spinbutton.vertical:dir(rtl) .button:last-child:insensitive {
+    -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923); }
+    .spinbutton.vertical .button:last-child:disabled, .spinbutton.vertical:dir(rtl) .button:last-child:disabled {
       color: @insensitive_fg_color;
       border-color: #1c1c1f;
-    background-image: linear-gradient(to bottom, #2c2c2e);
+    background-image: image(#2c2c2e);
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px alpha(white,0.08); }
-      .spinbutton.vertical .button:last-child:insensitive > .label, .spinbutton.vertical:dir(rtl) .button:last-child:insensitive > .label {
+      .spinbutton.vertical .button:last-child:disabled > .label, .spinbutton.vertical:dir(rtl) .button:last-child:disabled > .label {
         color: inherit; }
     .spinbutton.vertical .button:last-child:backdrop, .spinbutton.vertical:dir(rtl) .button:last-child:backdrop {
       color: @theme_unfocused_fg_color;
@@ -2020,24 +2014,24 @@ GtkColorButton.button, .header-bar GtkColorButton.button.titlebutton,
 				0 -2px alpha(black, 0.01) inset,
 				0 -3px alpha(black, 0.005) inset;
     text-shadow: none;
-    icon-shadow: none; }
-  .spinbutton.vertical .button:backdrop:insensitive, .spinbutton.vertical:dir(rtl) .button:backdrop:insensitive {
+    -gtk-icon-shadow: none; }
+  .spinbutton.vertical .button:backdrop:disabled, .spinbutton.vertical:dir(rtl) .button:backdrop:disabled {
     color: #4a4a4d;
     border-color: #202022;
-      background-image: linear-gradient(to bottom, #2a2a2c);
+      background-image: image(#2a2a2c);
       text-shadow: none;
-      icon-shadow: none;
+      -gtk-icon-shadow: none;
       box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0);}
-    .spinbutton.vertical .button:backdrop:insensitive > .label, .spinbutton.vertical:dir(rtl) .button:backdrop:insensitive > .label {
+    .spinbutton.vertical .button:backdrop:disabled > .label, .spinbutton.vertical:dir(rtl) .button:backdrop:disabled > .label {
       color: inherit; }
 .spinbutton.vertical.entry, .spinbutton.vertical:dir(rtl).entry {
   border-radius: 0;
   padding-left: 3px;
   padding-right: 3px; }
-.spinbutton.vertical .button:first-child, .spinbutton.vertical:dir(rtl) .button:first-child, .spinbutton.vertical .button:first-child:active, .spinbutton.vertical:dir(rtl) .button:first-child:active, .spinbutton.vertical .button:first-child:hover, .spinbutton.vertical:dir(rtl) .button:first-child:hover, .spinbutton.vertical .button:first-child:insensitive, .spinbutton.vertical:dir(rtl) .button:first-child:insensitive, .spinbutton.vertical .button:first-child:backdrop, .spinbutton.vertical:dir(rtl) .button:first-child:backdrop, .spinbutton.vertical:dir(rtl) .button:first-child, .spinbutton.vertical:dir(rtl) .button:first-child:active, .spinbutton.vertical:dir(rtl) .button:first-child:hover, .spinbutton.vertical:dir(rtl) .button:first-child:insensitive, .spinbutton.vertical:dir(rtl) .button:first-child:backdrop {
+.spinbutton.vertical .button:first-child, .spinbutton.vertical:dir(rtl) .button:first-child, .spinbutton.vertical .button:first-child:active, .spinbutton.vertical:dir(rtl) .button:first-child:active, .spinbutton.vertical .button:first-child:hover, .spinbutton.vertical:dir(rtl) .button:first-child:hover, .spinbutton.vertical .button:first-child:disabled, .spinbutton.vertical:dir(rtl) .button:first-child:disabled, .spinbutton.vertical .button:first-child:backdrop, .spinbutton.vertical:dir(rtl) .button:first-child:backdrop, .spinbutton.vertical:dir(rtl) .button:first-child, .spinbutton.vertical:dir(rtl) .button:first-child:active, .spinbutton.vertical:dir(rtl) .button:first-child:hover, .spinbutton.vertical:dir(rtl) .button:first-child:disabled, .spinbutton.vertical:dir(rtl) .button:first-child:backdrop {
   border-radius: 3px 3px 0 0;
   border-style: solid solid none solid; }
-.spinbutton.vertical .button:last-child, .spinbutton.vertical:dir(rtl) .button:last-child, .spinbutton.vertical .button:last-child:active, .spinbutton.vertical:dir(rtl) .button:last-child:active, .spinbutton.vertical .button:last-child:hover, .spinbutton.vertical:dir(rtl) .button:last-child:hover, .spinbutton.vertical .button:last-child:insensitive, .spinbutton.vertical:dir(rtl) .button:last-child:insensitive, .spinbutton.vertical .button:last-child:backdrop, .spinbutton.vertical:dir(rtl) .button:last-child:backdrop, .spinbutton.vertical:dir(rtl) .button:last-child, .spinbutton.vertical:dir(rtl) .button:last-child:active, .spinbutton.vertical:dir(rtl) .button:last-child:hover, .spinbutton.vertical:dir(rtl) .button:last-child:insensitive, .spinbutton.vertical:dir(rtl) .button:last-child:backdrop {
+.spinbutton.vertical .button:last-child, .spinbutton.vertical:dir(rtl) .button:last-child, .spinbutton.vertical .button:last-child:active, .spinbutton.vertical:dir(rtl) .button:last-child:active, .spinbutton.vertical .button:last-child:hover, .spinbutton.vertical:dir(rtl) .button:last-child:hover, .spinbutton.vertical .button:last-child:disabled, .spinbutton.vertical:dir(rtl) .button:last-child:disabled, .spinbutton.vertical .button:last-child:backdrop, .spinbutton.vertical:dir(rtl) .button:last-child:backdrop, .spinbutton.vertical:dir(rtl) .button:last-child, .spinbutton.vertical:dir(rtl) .button:last-child:active, .spinbutton.vertical:dir(rtl) .button:last-child:hover, .spinbutton.vertical:dir(rtl) .button:last-child:disabled, .spinbutton.vertical:dir(rtl) .button:last-child:backdrop {
   border-radius: 0 0 3px 3px;
   border-style: none solid solid solid; }
 GtkTreeView .spinbutton.entry, GtkTreeView .spinbutton.entry:focus {
@@ -2054,24 +2048,22 @@ GtkComboBox {
   -GtkComboBox-arrow-scaling: 0.5;
   -GtkComboBox-shadow-type: none;
   text-shadow: 0 -1px rgba(0,0,0, 0.76923);
-  icon-shadow: 0 -1px rgba(0,0,0, 0.76923); }
+  -gtk-icon-shadow: 0 -1px rgba(0,0,0, 0.76923); }
   GtkComboBox > .the-button-in-the-combobox {
     padding-top: 3px;
     padding-bottom: 4px; }
-  GtkComboBox:insensitive {
+  GtkComboBox:disabled {
     color: @insensitive_fg_color;
     text-shadow: none;
-    icon-shadow: none; }
+    -gtk-icon-shadow: none; }
   GtkComboBox:backdrop {
     color: @theme_unfocused_fg_color;
     text-shadow: none;
-    icon-shadow: none; }
-  GtkComboBox:backdrop:insensitive {
+    -gtk-icon-shadow: none; }
+  GtkComboBox:backdrop:disabled {
     color: #4a4a4d; }
   GtkComboBox .menuitem {
     text-shadow: none; }
-  GtkComboBox .separator.vertical {
-    -GtkWidget-wide-separators: true; }
   GtkComboBox.combobox-entry .entry:dir(ltr) {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0; }
@@ -2181,8 +2173,8 @@ GtkComboBox {
   border-image: linear-gradient(to right, rgba(161, 161, 161, 0), alpha(#fdfdff,0.95) 20%, alpha(#fdfdff,0.95) 80%, rgba(161, 161, 161, 0) 100%) 1 0 0 0/ 1px 0 0 0 stretch;
   border-radius: 7px 7px 0 0;
   border-bottom-color: #1c1c1e;
-  background-color: transparent;
-  background-image: linear-gradient(to bottom, rgba(255,255,255,0.22), rgba(255,255,255,0.06) ), url("assets/background-dark-transparent.png");
+  background-color: #2C2C2E;
+  background-image: linear-gradient(to bottom, rgba(255,255,255,0.88), rgba(255,255,255,0.44) ), url("assets/background-dark.png");
   box-shadow: 0 1px #49494b, inset 0 -1px 2px #49494b, inset 0 1px 2px alpha(white,0.35), inset 0 -1px #1c1c1e;
   text-shadow: 0 1px alpha(white,0.65); }
 
@@ -2200,15 +2192,15 @@ GtkComboBox {
   .titlebar.header-bar:backdrop {
     border-color: #202022;
     border-image: linear-gradient(to right, rgba(161, 161, 161, 0), alpha(#dddddf,0.95) 20%, alpha(#dddddf,0.95) 80%, rgba(161, 161, 161, 0) 100%) 1 0 0 0/ 1px 0 0 0 stretch;
-    background-color: transparent;
-    background-image: linear-gradient(to bottom, rgba(255,255,255,0.15), rgba(255,255,255,0.04)), url("assets/background-dark-transparent-backdrop.png");
+    background-color: #2C2C2E;
+    background-image: linear-gradient(to bottom, rgba(255,255,255,0.75), rgba(255,255,255,0.15)), url("assets/background-dark-backdrop.png");
     box-shadow: 0 1px #4c4c4e,inset 0 -1px 0px #4c4c4e, inset 0 1px 2px alpha(white,0.15), inset 0 -1px #202022; }
 
 .ssd .titlebar:backdrop {
    color: @theme_unfocused_fg_color;
    border-style: none;
    border-image: linear-gradient(to right, rgba(161, 161, 161, 0), alpha(#dddddf,0.1) 20%, alpha(#dddddf,0.1) 80%, rgba(161, 161, 161, 0) 100%) 1 0 0 0/ 1px 0 0 0 stretch;
-   background-image: linear-gradient(to bottom, rgba(255,255,255,0.04), rgba(255,255,255,0.0)), url("assets/background-dark.png");
+   background-image: linear-gradient(to bottom, rgba(255,255,255,0.25), rgba(255,255,255,0.05)), url("assets/background-dark.png");
     box-shadow: 0 1px #4c4c4e;
     }
     
@@ -2225,26 +2217,24 @@ GtkComboBox {
   .titlebar .header-bar-separator, .titlebar > GtkBox > .separator.vertical,
   .header-bar .header-bar-separator,
   .header-bar > GtkBox > .separator.vertical {
-    -GtkWidget-wide-separators: true;
-    -GtkWidget-separator-width: 1px;
     border-width: 0 1px;
     border-image: linear-gradient(to bottom, rgba(161, 161, 161, 0), #a1a1a1 30%, #a1a1a1 70%, rgba(161, 161, 161, 0) 100%) 0 1/0 1px stretch; }
     .titlebar .header-bar-separator:backdrop, .titlebar > GtkBox > .separator.vertical:backdrop,
     .header-bar .header-bar-separator:backdrop,
     .header-bar > GtkBox > .separator.vertical:backdrop {
-      border-image: linear-gradient(to bottom, rgba(168, 168, 168, 0.5)) 0 1/1px 1px; }
+      border-image: image(rgba(168, 168, 168, 0.5)) 0 1/1px 1px; }
   .titlebar.selection-mode,
   .header-bar.selection-mode {
     color: #ffffff;
     border-image: linear-gradient(to right, rgba(161, 161, 161, 0), alpha(#fff,0.5) 20%, alpha(#fff,0.5) 80%, rgba(161, 161, 161, 0) 100%) 1 0 0 0/ 1px 0 0 0 stretch;
     text-shadow: 0 -1px rgba(0, 0, 0, 0.5);
     border-color: #1c1c1c;
-    background-image: linear-gradient(to bottom, rgba(0,0,0,0.06), rgba(0,0,0,0.32)), url("assets/selected-background-dark-transparent.png");
+    background-image: linear-gradient(to bottom, rgba(0,0,0,0.06), rgba(0,0,0,0.32)), url("assets/selected-background-dark.png");
     box-shadow: 0 1px #49494b, inset 0 -1px 2px #49494b, inset 0 1px 2px alpha(white,0.15), inset 0 -1px #1c1c1e; }
     .titlebar.selection-mode:backdrop,
     .header-bar.selection-mode:backdrop {
       border-image: linear-gradient(to right, rgba(161, 161, 161, 0), alpha(#dddddf,0.5) 20%, alpha(#dddddf,0.5) 80%, rgba(161, 161, 161, 0) 100%) 1 0 0 0/ 1px 0 0 0 stretch;
-      background-image: linear-gradient(to bottom, rgba(0,0,0,0.06), rgba(0,0,0,0.2)), url("assets/selected-background-dark-transparent-backdrop.png");
+      background-image: linear-gradient(to bottom, rgba(0,0,0,0.06), rgba(0,0,0,0.2)), url("assets/selected-background-dark-backdrop.png");
       box-shadow: 0 1px #4c4c4e,inset 0 -1px 0px #4c4c4e, inset 0 1px 2px alpha(white,0.09), inset 0 -1px #202022; }
     .titlebar.selection-mode .button,
     .header-bar.selection-mode .button {
@@ -2263,7 +2253,7 @@ GtkComboBox {
                                     alpha(black, 0.25),
                                     alpha(black, 0.10));
   box-shadow: inset 0 1px 2px 0px alpha(white, 0.3), inset 0 1px alpha(white,0.25), 0 1px 2px 0 alpha(black, 0.35);
-  icon-shadow: 0 1px rgba(0,0,0,0.5);
+  -gtk-icon-shadow: 0 1px rgba(0,0,0,0.5);
   text-shadow: 0 1px rgba(0,0,0,0.5);
 }
       .titlebar.selection-mode .button.flat, .titlebar.selection-mode .sidebar-button.button,
@@ -2272,14 +2262,14 @@ GtkComboBox {
       .header-bar.selection-mode .sidebar-button.button,
       .header-bar.selection-mode .titlebutton.button {
         border-color: transparent;
-        background-color: transparent;
+        background-color: #2C2C2E;
         background-image: none;
         box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0);
         text-shadow: none;
-        icon-shadow: none; }
+        -gtk-icon-shadow: none; }
       .titlebar.selection-mode .button:hover,
       .header-bar.selection-mode .button:hover{
-  icon-shadow: 0 1px 3px rgba(0,0,0,0.95), 0 -1px 3px rgba(0,0,0,0.95);
+  -gtk-icon-shadow: 0 1px 3px rgba(0,0,0,0.95), 0 -1px 3px rgba(0,0,0,0.95);
   text-shadow: 0 1px 3px rgba(0,0,0,0.95), 0 -1px 3px rgba(0,0,0,0.95); }
       .titlebar.selection-mode .button:active, .titlebar.selection-mode .button:checked,
       .header-bar.selection-mode .button:active,
@@ -2293,7 +2283,7 @@ GtkComboBox {
                                     alpha(black, 0.35),
                                     alpha(black, 0.55));
   box-shadow: inset 0 1px 2px 0 alpha(black, 0.35), 0 1px alpha(white, 0.65);
-  icon-shadow: 0 1px rgba(0,0,0,0.45);
+  -gtk-icon-shadow: 0 1px rgba(0,0,0,0.45);
   text-shadow: 0 1px rgba(0,0,0,0.45);}
       .titlebar.selection-mode .button:backdrop, .titlebar.selection-mode .button.flat:backdrop, .titlebar.selection-mode .sidebar-button.button:backdrop,
       .titlebar.selection-mode .titlebutton.button:backdrop,
@@ -2311,9 +2301,9 @@ GtkComboBox {
                                     alpha(black, 0.2),
                                     alpha(black, 0.05));
         text-shadow: none;
-        icon-shadow: none;
+        -gtk-icon-shadow: none;
         box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(164, 199, 236, 0);
-        -gtk-image-effect: none;
+        -gtk-icon-effect: none;
         border-color: #202022; }
         .titlebar.selection-mode .button:backdrop:active, .titlebar.selection-mode .button:backdrop:checked, .titlebar.selection-mode .button.flat:backdrop:active, .titlebar.selection-mode .sidebar-button.button:backdrop:active,
         .titlebar.selection-mode .titlebutton.button:backdrop:active, .titlebar.selection-mode .button.flat:backdrop:checked, .titlebar.selection-mode .sidebar-button.button:backdrop:checked,
@@ -2328,95 +2318,95 @@ GtkComboBox {
         .header-bar.selection-mode .titlebutton.button:backdrop:checked{
           color: shade(@theme_unfocused_fg_color, 1.2);
           border-color: alpha(black, 0.6);
-          background-image: linear-gradient(to bottom, alpha(black,0.45));
+          background-image: image(alpha(black,0.45));
           box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(164, 199, 236, 0);}
-        .titlebar.selection-mode .button:backdrop:insensitive, .titlebar.selection-mode .button.flat:backdrop:insensitive, .titlebar.selection-mode .sidebar-button.button:backdrop:insensitive,
-        .titlebar.selection-mode .titlebutton.button:backdrop:insensitive,
-        .header-bar.selection-mode .button:backdrop:insensitive,
-        .header-bar.selection-mode .button.flat:backdrop:insensitive,
-        .header-bar.selection-mode .sidebar-button.button:backdrop:insensitive,
-        .header-bar.selection-mode .titlebutton.button:backdrop:insensitive {
+        .titlebar.selection-mode .button:backdrop:disabled, .titlebar.selection-mode .button.flat:backdrop:disabled, .titlebar.selection-mode .sidebar-button.button:backdrop:disabled,
+        .titlebar.selection-mode .titlebutton.button:backdrop:disabled,
+        .header-bar.selection-mode .button:backdrop:disabled,
+        .header-bar.selection-mode .button.flat:backdrop:disabled,
+        .header-bar.selection-mode .sidebar-button.button:backdrop:disabled,
+        .header-bar.selection-mode .titlebutton.button:backdrop:disabled {
           color: #4a4a4d;
           border-color: alpha(black,0.25);
-          background-image: linear-gradient(to bottom, alpha(black,0.1));
+          background-image: image(alpha(black,0.1));
           text-shadow: none;
-          icon-shadow: none;
+          -gtk-icon-shadow: none;
           box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(164, 199, 236, 0); }
-          .titlebar.selection-mode .button:backdrop:insensitive > .label, .titlebar.selection-mode .button.flat:backdrop:insensitive > .label, .titlebar.selection-mode .sidebar-button.button:backdrop:insensitive > .label,
-          .titlebar.selection-mode .titlebutton.button:backdrop:insensitive > .label,
-          .header-bar.selection-mode .button:backdrop:insensitive > .label,
-          .header-bar.selection-mode .button.flat:backdrop:insensitive > .label,
-          .header-bar.selection-mode .sidebar-button.button:backdrop:insensitive > .label,
-          .header-bar.selection-mode .titlebutton.button:backdrop:insensitive > .label {
+          .titlebar.selection-mode .button:backdrop:disabled > .label, .titlebar.selection-mode .button.flat:backdrop:disabled > .label, .titlebar.selection-mode .sidebar-button.button:backdrop:disabled > .label,
+          .titlebar.selection-mode .titlebutton.button:backdrop:disabled > .label,
+          .header-bar.selection-mode .button:backdrop:disabled > .label,
+          .header-bar.selection-mode .button.flat:backdrop:disabled > .label,
+          .header-bar.selection-mode .sidebar-button.button:backdrop:disabled > .label,
+          .header-bar.selection-mode .titlebutton.button:backdrop:disabled > .label {
             color: inherit; }
-        .titlebar.selection-mode .button:backdrop:insensitive:active, .titlebar.selection-mode .button:backdrop:insensitive:checked, .titlebar.selection-mode .button.flat:backdrop:insensitive:active, .titlebar.selection-mode .sidebar-button.button:backdrop:insensitive:active,
-        .titlebar.selection-mode .titlebutton.button:backdrop:insensitive:active, .titlebar.selection-mode .button.flat:backdrop:insensitive:checked, .titlebar.selection-mode .sidebar-button.button:backdrop:insensitive:checked,
-        .titlebar.selection-mode .titlebutton.button:backdrop:insensitive:checked,
-        .header-bar.selection-mode .button:backdrop:insensitive:active,
-        .header-bar.selection-mode .button:backdrop:insensitive:checked,
-        .header-bar.selection-mode .button.flat:backdrop:insensitive:active,
-        .header-bar.selection-mode .sidebar-button.button:backdrop:insensitive:active,
-        .header-bar.selection-mode .titlebutton.button:backdrop:insensitive:active,
-        .header-bar.selection-mode .button.flat:backdrop:insensitive:checked,
-        .header-bar.selection-mode .sidebar-button.button:backdrop:insensitive:checked,
-        .header-bar.selection-mode .titlebutton.button:backdrop:insensitive:checked {
+        .titlebar.selection-mode .button:backdrop:disabled:active, .titlebar.selection-mode .button:backdrop:disabled:checked, .titlebar.selection-mode .button.flat:backdrop:disabled:active, .titlebar.selection-mode .sidebar-button.button:backdrop:disabled:active,
+        .titlebar.selection-mode .titlebutton.button:backdrop:disabled:active, .titlebar.selection-mode .button.flat:backdrop:disabled:checked, .titlebar.selection-mode .sidebar-button.button:backdrop:disabled:checked,
+        .titlebar.selection-mode .titlebutton.button:backdrop:disabled:checked,
+        .header-bar.selection-mode .button:backdrop:disabled:active,
+        .header-bar.selection-mode .button:backdrop:disabled:checked,
+        .header-bar.selection-mode .button.flat:backdrop:disabled:active,
+        .header-bar.selection-mode .sidebar-button.button:backdrop:disabled:active,
+        .header-bar.selection-mode .titlebutton.button:backdrop:disabled:active,
+        .header-bar.selection-mode .button.flat:backdrop:disabled:checked,
+        .header-bar.selection-mode .sidebar-button.button:backdrop:disabled:checked,
+        .header-bar.selection-mode .titlebutton.button:backdrop:disabled:checked {
           color: #7a7a7d;
           border-color: alpha(black, 0.4);
-          background-image: linear-gradient(to bottom, alpha(black,0.25));
+          background-image: image(alpha(black,0.25));
           box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(164, 199, 236, 0); }
-          .titlebar.selection-mode .button:backdrop:insensitive:active > .label, .titlebar.selection-mode .button:backdrop:insensitive:checked > .label, .titlebar.selection-mode .button.flat:backdrop:insensitive:active > .label, .titlebar.selection-mode .sidebar-button.button:backdrop:insensitive:active > .label,
-          .titlebar.selection-mode .titlebutton.button:backdrop:insensitive:active > .label, .titlebar.selection-mode .button.flat:backdrop:insensitive:checked > .label, .titlebar.selection-mode .sidebar-button.button:backdrop:insensitive:checked > .label,
-          .titlebar.selection-mode .titlebutton.button:backdrop:insensitive:checked > .label,
-          .header-bar.selection-mode .button:backdrop:insensitive:active > .label,
-          .header-bar.selection-mode .button:backdrop:insensitive:checked > .label,
-          .header-bar.selection-mode .button.flat:backdrop:insensitive:active > .label,
-          .header-bar.selection-mode .sidebar-button.button:backdrop:insensitive:active > .label,
-          .header-bar.selection-mode .titlebutton.button:backdrop:insensitive:active > .label,
-          .header-bar.selection-mode .button.flat:backdrop:insensitive:checked > .label,
-          .header-bar.selection-mode .sidebar-button.button:backdrop:insensitive:checked > .label,
-          .header-bar.selection-mode .titlebutton.button:backdrop:insensitive:checked > .label
+          .titlebar.selection-mode .button:backdrop:disabled:active > .label, .titlebar.selection-mode .button:backdrop:disabled:checked > .label, .titlebar.selection-mode .button.flat:backdrop:disabled:active > .label, .titlebar.selection-mode .sidebar-button.button:backdrop:disabled:active > .label,
+          .titlebar.selection-mode .titlebutton.button:backdrop:disabled:active > .label, .titlebar.selection-mode .button.flat:backdrop:disabled:checked > .label, .titlebar.selection-mode .sidebar-button.button:backdrop:disabled:checked > .label,
+          .titlebar.selection-mode .titlebutton.button:backdrop:disabled:checked > .label,
+          .header-bar.selection-mode .button:backdrop:disabled:active > .label,
+          .header-bar.selection-mode .button:backdrop:disabled:checked > .label,
+          .header-bar.selection-mode .button.flat:backdrop:disabled:active > .label,
+          .header-bar.selection-mode .sidebar-button.button:backdrop:disabled:active > .label,
+          .header-bar.selection-mode .titlebutton.button:backdrop:disabled:active > .label,
+          .header-bar.selection-mode .button.flat:backdrop:disabled:checked > .label,
+          .header-bar.selection-mode .sidebar-button.button:backdrop:disabled:checked > .label,
+          .header-bar.selection-mode .titlebutton.button:backdrop:disabled:checked > .label
            {
             color: inherit; }
       .titlebar.selection-mode .button.flat:backdrop, .titlebar.selection-mode .sidebar-button.button:backdrop,
-      .titlebar.selection-mode .titlebutton.button:backdrop, .titlebar.selection-mode .button.flat:insensitive, .titlebar.selection-mode .sidebar-button.button:insensitive,
-      .titlebar.selection-mode .titlebutton.button:insensitive, .titlebar.selection-mode .button.flat:insensitive:backdrop, .titlebar.selection-mode .sidebar-button.button:insensitive:backdrop,
-      .titlebar.selection-mode .titlebutton.button:insensitive:backdrop,
+      .titlebar.selection-mode .titlebutton.button:backdrop, .titlebar.selection-mode .button.flat:disabled, .titlebar.selection-mode .sidebar-button.button:disabled,
+      .titlebar.selection-mode .titlebutton.button:disabled, .titlebar.selection-mode .button.flat:disabled:backdrop, .titlebar.selection-mode .sidebar-button.button:disabled:backdrop,
+      .titlebar.selection-mode .titlebutton.button:disabled:backdrop,
       .header-bar.selection-mode .button.flat:backdrop,
       .header-bar.selection-mode .sidebar-button.button:backdrop,
       .header-bar.selection-mode .titlebutton.button:backdrop,
-      .header-bar.selection-mode .button.flat:insensitive,
-      .header-bar.selection-mode .sidebar-button.button:insensitive,
-      .header-bar.selection-mode .titlebutton.button:insensitive,
-      .header-bar.selection-mode .button.flat:insensitive:backdrop,
-      .header-bar.selection-mode .sidebar-button.button:insensitive:backdrop,
-      .header-bar.selection-mode .titlebutton.button:insensitive:backdrop {
+      .header-bar.selection-mode .button.flat:disabled,
+      .header-bar.selection-mode .sidebar-button.button:disabled,
+      .header-bar.selection-mode .titlebutton.button:disabled,
+      .header-bar.selection-mode .button.flat:disabled:backdrop,
+      .header-bar.selection-mode .sidebar-button.button:disabled:backdrop,
+      .header-bar.selection-mode .titlebutton.button:disabled:backdrop {
         border-color: transparent;
-        background-color: transparent;
+        background-color: #2C2C2E;
         background-image: none;
         box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0);
         text-shadow: none;
-        icon-shadow: none; }
-      .titlebar.selection-mode .button:insensitive,
-      .header-bar.selection-mode .button:insensitive {
+        -gtk-icon-shadow: none; }
+      .titlebar.selection-mode .button:disabled,
+      .header-bar.selection-mode .button:disabled {
         color: @insensitive_fg_color;
         border-color: alpha(black,0.25);
-        background-image: linear-gradient(to bottom, alpha(black, 0.15));
+        background-image: image(alpha(black, 0.15));
         text-shadow: none;
-        icon-shadow: none;
+        -gtk-icon-shadow: none;
         box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px alpha(white, 0.2); }
-        .titlebar.selection-mode .button:insensitive > .label,
-        .header-bar.selection-mode .button:insensitive > .label {
+        .titlebar.selection-mode .button:disabled > .label,
+        .header-bar.selection-mode .button:disabled > .label {
           color: inherit; }
-        .titlebar.selection-mode .button:insensitive:active, .titlebar.selection-mode .button:insensitive:checked,
-        .header-bar.selection-mode .button:insensitive:active,
-        .header-bar.selection-mode .button:insensitive:checked {
+        .titlebar.selection-mode .button:disabled:active, .titlebar.selection-mode .button:disabled:checked,
+        .header-bar.selection-mode .button:disabled:active,
+        .header-bar.selection-mode .button:disabled:checked {
           color: shade(@insensitive_fg_color, 1.2);
           border-color: #1c5187;
           background-image: linear-gradient(to bottom, alpha(black,0.2), alpha(black, 0.4));
           box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px alpha(white, 0.2); }
-          .titlebar.selection-mode .button:insensitive:active > .label, .titlebar.selection-mode .button:insensitive:checked > .label,
-          .header-bar.selection-mode .button:insensitive:active > .label,
-          .header-bar.selection-mode .button:insensitive:checked > .label {
+          .titlebar.selection-mode .button:disabled:active > .label, .titlebar.selection-mode .button:disabled:checked > .label,
+          .header-bar.selection-mode .button:disabled:active > .label,
+          .header-bar.selection-mode .button:disabled:checked > .label {
             color: inherit; }
       .titlebar.selection-mode .button.suggested-action,
       .header-bar.selection-mode .button.suggested-action {
@@ -2447,7 +2437,7 @@ GtkComboBox {
 				0 -3px alpha(black, 0.01) inset,
 				0 1px alpha(white, 0.08);
     text-shadow: 0 -1px rgba(0, 0, 0, 0.54353);
-    icon-shadow: 0 -1px rgba(0, 0, 0, 0.54353); }
+    -gtk-icon-shadow: 0 -1px rgba(0, 0, 0, 0.54353); }
         .titlebar.selection-mode .button.suggested-action:hover,
         .header-bar.selection-mode .button.suggested-action:hover {
           color: white;
@@ -2476,7 +2466,7 @@ GtkComboBox {
 				0 -3px alpha(black, 0.01) inset,
 				0 1px 2px 0 rgba(0,0,0,0.2);
       text-shadow: 0 -1px rgba(0, 0, 0, 0.51153);
-      icon-shadow: 0 -1px rgba(0, 0, 0, 0.51153); }
+      -gtk-icon-shadow: 0 -1px rgba(0, 0, 0, 0.51153); }
         .titlebar.selection-mode .button.suggested-action:active,
         .header-bar.selection-mode .button.suggested-action:active {
           color: white;
@@ -2485,19 +2475,19 @@ GtkComboBox {
       background-image: linear-gradient(to bottom, 
                                       mix(shade(@theme_selected_bg_color, 0.9), @theme_selected_bg_color, 0.30), 
                                       mix(shade(@theme_selected_bg_color, 1.2), @theme_selected_bg_color, 0.25));
-      background-color: transparent;
+      background-color: #2C2C2E;
       text-shadow: 0 -1px rgba(0, 0, 0, 0.62353);
-      icon-shadow: 0 -1px rgba(0, 0, 0, 0.62353);
+      -gtk-icon-shadow: 0 -1px rgba(0, 0, 0, 0.62353);
       box-shadow: inset 0 1px rgba(0, 0, 0, 0.07), inset 0 2px 1px -2px rgba(0, 0, 0, 0.6), 0 1px alpha(white,0.12); }
-        .titlebar.selection-mode .button.suggested-action:insensitive,
-        .header-bar.selection-mode .button.suggested-action:insensitive {
+        .titlebar.selection-mode .button.suggested-action:disabled,
+        .header-bar.selection-mode .button.suggested-action:disabled {
           border-color: #1c1c1f;
-    background-image: linear-gradient(to bottom, #2c2c2e);
+    background-image: image(#2c2c2e);
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px alpha(white,0.08); }
-          .titlebar.selection-mode .button.suggested-action:insensitive > .label,
-          .header-bar.selection-mode .button.suggested-action:insensitive > .label {
+          .titlebar.selection-mode .button.suggested-action:disabled > .label,
+          .header-bar.selection-mode .button.suggested-action:disabled > .label {
             color: inherit; }
         .titlebar.selection-mode .button.suggested-action:backdrop,
         .header-bar.selection-mode .button.suggested-action:backdrop {
@@ -2525,23 +2515,23 @@ GtkComboBox {
 				0 -2px alpha(black, 0.01) inset,
 				0 -3px alpha(black, 0.005) inset;
       text-shadow: none;
-      icon-shadow: none; }
-        .titlebar.selection-mode .button.suggested-action:backdrop:insensitive,
-        .header-bar.selection-mode .button.suggested-action:backdrop:insensitive {
+      -gtk-icon-shadow: none; }
+        .titlebar.selection-mode .button.suggested-action:backdrop:disabled,
+        .header-bar.selection-mode .button.suggested-action:backdrop:disabled {
           color: #4a4a4d;
         border-color: #202022;
-        background-image: linear-gradient(to bottom, #262628);
+        background-image: image(#262628);
         text-shadow: none;
-        icon-shadow: none;
+        -gtk-icon-shadow: none;
         box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0); }
-          .titlebar.selection-mode .button.suggested-action:backdrop:insensitive > .label,
-          .header-bar.selection-mode .button.suggested-action:backdrop:insensitive > .label {
+          .titlebar.selection-mode .button.suggested-action:backdrop:disabled > .label,
+          .header-bar.selection-mode .button.suggested-action:backdrop:disabled > .label {
             color: inherit; }
     .titlebar.selection-mode .selection-menu, .titlebar.selection-mode .selection-menu:backdrop,
     .header-bar.selection-mode .selection-menu,
     .header-bar.selection-mode .selection-menu:backdrop {
       border-color: rgba(74, 144, 217, 0);
-      background-image: linear-gradient(to bottom, rgba(74, 144, 217, 0));
+      background-image: image(rgba(74, 144, 217, 0));
       box-shadow: none;
       padding-left: 10px;
       padding-right: 10px; }
@@ -2553,7 +2543,7 @@ GtkComboBox {
       .header-bar.selection-mode .selection-menu .arrow {
         -gtk-icon-source: -gtk-icontheme("pan-down-symbolic");
         color: rgba(255, 255, 255, 0.5);
-        icon-shadow: none; }
+        -gtk-icon-shadow: none; }
   .tiled .titlebar, .maximized .titlebar, .tiled
   .header-bar, .maximized
   .header-bar,
@@ -2574,33 +2564,33 @@ GtkComboBox {
       
 NautilusToolbar.titlebar.header-bar .raised.linked .button.image-button {
   background-image: none;
-  background-color: transparent;
+  background-color: #2C2C2E;
   border-color: transparent;
   box-shadow: none;
   color: black;
   text-shadow: 0 1px rgba(255,255,255,0.65);
-  icon-shadow: 0 1px rgba(255,255,255,0.65);
+  -gtk-icon-shadow: 0 1px rgba(255,255,255,0.65);
   }
 
 NautilusToolbar.titlebar.header-bar .raised.linked .button.image-button:hover {
-  icon-shadow: 0 2px 3px rgba(255,255,255,0.95),0 -2px 3px rgba(255,255,255,0.95),0 1px rgba(255,255,255,0.65), 0 -1px rgba(255,255,255,0.65);
+  -gtk-icon-shadow: 0 2px 3px rgba(255,255,255,0.95),0 -2px 3px rgba(255,255,255,0.95),0 1px rgba(255,255,255,0.65), 0 -1px rgba(255,255,255,0.65);
   }
 
 NautilusToolbar.titlebar.header-bar .raised.linked .button.image-button:active,
 NautilusToolbar.titlebar.header-bar .raised.linked .button.image-button:checked {
   color: white;
-  icon-shadow: 0 2px 3px rgba(0,0,0,0.95),0 -2px 3px rgba(0,0,0,0.95), 0 1px alpha(black, 0.65), 0 -1px alpha(black, 0.65);
+  -gtk-icon-shadow: 0 2px 3px rgba(0,0,0,0.95),0 -2px 3px rgba(0,0,0,0.95), 0 1px alpha(black, 0.65), 0 -1px alpha(black, 0.65);
   }
 
-NautilusToolbar.titlebar.header-bar .raised.linked .button.image-button:insensitive,
-NautilusToolbar.titlebar.header-bar .raised.linked .button.image-button:insensitive:backdrop {
+NautilusToolbar.titlebar.header-bar .raised.linked .button.image-button:disabled,
+NautilusToolbar.titlebar.header-bar .raised.linked .button.image-button:disabled:backdrop {
   color: @insensitive_fg_color;
   }
 
 NautilusToolbar.titlebar.header-bar .raised.linked .button.image-button:backdrop {
   color: @theme_unfocused_fg_color;
   text-shadow: none;
-  icon-shadow: none;
+  -gtk-icon-shadow: none;
   }
 
 /************
@@ -2691,9 +2681,9 @@ NautilusToolbar.titlebar.header-bar .raised.linked .button.image-button:backdrop
     background-position: center bottom;
     background-size: 13px 13px, auto;
     
-    icon-shadow: 0 1px 3px rgba(0,0,0,0.75), 0 -1px 3px rgba(0,0,0,0.75);
+    -gtk-icon-shadow: 0 1px 3px rgba(0,0,0,0.75), 0 -1px 3px rgba(0,0,0,0.75);
     text-shadow: 0 1px 3px rgba(0,0,0,0.75), 0 -1px 3px rgba(0,0,0,0.75);
-    -gtk-image-effect: highlight;
+    -gtk-icon-effect: highlight;
 }
 
  NemoPathBar.raised.linked .button:backdrop,
@@ -2795,7 +2785,7 @@ NautilusToolbar.titlebar.header-bar .raised.linked .button.image-button:backdrop
                                       rgba(0,0,0,0.0) 20%,
                                       rgba(0,0,0,0.0) 
                                       );
-    icon-shadow: 0 1px 3px rgba(0,0,0,0.8), 0 -1px 3px rgba(0,0,0,0.8);
+    -gtk-icon-shadow: 0 1px 3px rgba(0,0,0,0.8), 0 -1px 3px rgba(0,0,0,0.8);
     text-shadow: 0 1px 3px rgba(0,0,0,0.8), 0 -1px 3px rgba(0,0,0,0.8);                                  
     color: #bbbbbf;
 	background-repeat: no-repeat;
@@ -2873,8 +2863,8 @@ NautilusToolbar.titlebar.header-bar .raised.linked .button.image-button:backdrop
 .path-bar .button:checked:hover:first-child,
 .path-bar .button:checked:first-child:backdrop,
 .path-bar .button:checked:hover:first-child:backdrop,
-.path-bar .button:insensitive:first-child,
-.path-bar .button:insensitive:first-child:backdrop,
+.path-bar .button:disabled:first-child,
+.path-bar .button:disabled:first-child:backdrop,
 .titlebar .path-bar .button:first-child,
 .titlebar .path-bar .button:hover:first-child,
 .titlebar .path-bar .button:first-child:backdrop,
@@ -2887,8 +2877,8 @@ NautilusToolbar.titlebar.header-bar .raised.linked .button.image-button:backdrop
 .titlebar .path-bar .button:checked:hover:first-child,
 .titlebar .path-bar .button:checked:first-child:backdrop,
 .titlebar .path-bar .button:checked:hover:first-child:backdrop,
-.titlebar .path-bar .button:insensitive:first-child,
-.titlebar .path-bar .button:insensitive:first-child:backdrop,
+.titlebar .path-bar .button:disabled:first-child,
+.titlebar .path-bar .button:disabled:first-child:backdrop,
 .header-bar .path-bar .button:first-child,
 .header-bar .path-bar .button:hover:first-child,
 .header-bar .path-bar .button:first-child:backdrop,
@@ -2901,8 +2891,8 @@ NautilusToolbar.titlebar.header-bar .raised.linked .button.image-button:backdrop
 .header-bar .path-bar .button:checked:hover:first-child,
 .header-bar .path-bar .button:checked:first-child:backdrop,
 .header-bar .path-bar .button:checked:hover:first-child:backdrop,
-.header-bar .path-bar .button:insensitive:first-child,
-.header-bar .path-bar .button:insensitive:first-child:backdrop,
+.header-bar .path-bar .button:disabled:first-child,
+.header-bar .path-bar .button:disabled:first-child:backdrop,
 NemoPathBar.raised.linked .button:first-child,
 NemoPathBar.raised.linked .button:hover:first-child,
 NemoPathBar.raised.linked .button:first-child:backdrop,
@@ -2915,8 +2905,8 @@ NemoPathBar.raised.linked .button:checked:first-child,
 NemoPathBar.raised.linked .button:checked:hover:first-child,
 NemoPathBar.raised.linked .button:checked:first-child:backdrop,
 NemoPathBar.raised.linked .button:checked:hover:first-child:backdrop,
-NemoPathBar.raised.linked .button:insensitive:first-child,
-NemoPathBar.raised.linked .button:insensitive:first-child:backdrop {
+NemoPathBar.raised.linked .button:disabled:first-child,
+NemoPathBar.raised.linked .button:disabled:first-child:backdrop {
     border-radius: 30px;
     border-bottom-right-radius: 0;
     border-top-right-radius: 0;
@@ -2936,8 +2926,8 @@ NemoPathBar.raised.linked .button:insensitive:first-child:backdrop {
 .path-bar .button:checked:hover:last-child,
 .path-bar .button:checked:last-child:backdrop,
 .path-bar .button:checked:hover:last-child:backdrop,
-.path-bar .button:insensitive:last-child,
-.path-bar .button:insensitive:last-child:backdrop,
+.path-bar .button:disabled:last-child,
+.path-bar .button:disabled:last-child:backdrop,
 .titlebar .path-bar .button:last-child,
 .titlebar .path-bar .button:hover:last-child,
 .titlebar .path-bar .button:last-child:backdrop,
@@ -2950,8 +2940,8 @@ NemoPathBar.raised.linked .button:insensitive:first-child:backdrop {
 .titlebar .path-bar .button:checked:hover:last-child,
 .titlebar .path-bar .button:checked:last-child:backdrop,
 .titlebar .path-bar .button:checked:hover:last-child:backdrop,
-.titlebar .path-bar .button:insensitive:last-child,
-.titlebar .path-bar .button:insensitive:last-child:backdrop,
+.titlebar .path-bar .button:disabled:last-child,
+.titlebar .path-bar .button:disabled:last-child:backdrop,
 .header-bar .path-bar .button:last-child,
 .header-bar .path-bar .button:hover:last-child,
 .header-bar .path-bar .button:last-child:backdrop,
@@ -2964,8 +2954,8 @@ NemoPathBar.raised.linked .button:insensitive:first-child:backdrop {
 .header-bar .path-bar .button:checked:hover:last-child,
 .header-bar .path-bar .button:checked:last-child:backdrop,
 .header-bar .path-bar .button:checked:hover:last-child:backdrop,
-.header-bar .path-bar .button:insensitive:last-child,
-.header-bar .path-bar .button:insensitive:last-child:backdrop,
+.header-bar .path-bar .button:disabled:last-child,
+.header-bar .path-bar .button:disabled:last-child:backdrop,
 NemoPathBar.raised.linked .button:last-child,
 NemoPathBar.raised.linked .button:hover:last-child,
 NemoPathBar.raised.linked .button:last-child:backdrop,
@@ -2978,8 +2968,8 @@ NemoPathBar.raised.linked .button:checked:last-child,
 NemoPathBar.raised.linked .button:checked:hover:last-child,
 NemoPathBar.raised.linked .button:checked:last-child:backdrop,
 NemoPathBar.raised.linked .button:checked:hover:last-child:backdrop,
-NemoPathBar.raised.linked .button:insensitive:last-child,
-NemoPathBar.raised.linked .button:insensitive:last-child:backdrop {
+NemoPathBar.raised.linked .button:disabled:last-child,
+NemoPathBar.raised.linked .button:disabled:last-child:backdrop {
     border-width: 0px 1px 0px 1px;
     border-radius: 3px;
     border-bottom-left-radius: 0;
@@ -3003,8 +2993,8 @@ NemoPathBar.raised.linked .button:insensitive:last-child:backdrop {
 .path-bar .button:checked:hover:only-child,
 .path-bar .button:checked:only-child:backdrop,
 .path-bar .button:checked:hover:only-child:backdrop,
-.path-bar .button:insensitive:only-child,
-.path-bar .button:insensitive:only-child:backdrop,
+.path-bar .button:disabled:only-child,
+.path-bar .button:disabled:only-child:backdrop,
 .titlebar .path-bar .button:only-child,
 .titlebar .path-bar .button:hover:only-child,
 .titlebar .path-bar .button:only-child:backdrop,
@@ -3017,8 +3007,8 @@ NemoPathBar.raised.linked .button:insensitive:last-child:backdrop {
 .titlebar .path-bar .button:checked:hover:only-child,
 .titlebar .path-bar .button:checked:only-child:backdrop,
 .titlebar .path-bar .button:checked:hover:only-child:backdrop,
-.titlebar .path-bar .button:insensitive:only-child,
-.titlebar .path-bar .button:insensitive:only-child:backdrop,
+.titlebar .path-bar .button:disabled:only-child,
+.titlebar .path-bar .button:disabled:only-child:backdrop,
 .header-bar .path-bar .button:only-child,
 .header-bar .path-bar .button:hover:only-child,
 .header-bar .path-bar .button:only-child:backdrop,
@@ -3031,8 +3021,8 @@ NemoPathBar.raised.linked .button:insensitive:last-child:backdrop {
 .header-bar .path-bar .button:checked:hover:only-child,
 .header-bar .path-bar .button:checked:only-child:backdrop,
 .header-bar .path-bar .button:checked:hover:only-child:backdrop,
-.header-bar .path-bar .button:insensitive:only-child,
-.header-bar .path-bar .button:insensitive:only-child:backdrop,
+.header-bar .path-bar .button:disabled:only-child,
+.header-bar .path-bar .button:disabled:only-child:backdrop,
 .path-bar .header-bar .button.titlebutton:only-child,
 .path-bar .header-bar .button.titlebutton:hover:only-child,
 .path-bar .header-bar .button.titlebutton:only-child:backdrop,
@@ -3045,8 +3035,8 @@ NemoPathBar.raised.linked .button:insensitive:last-child:backdrop {
 .path-bar .header-bar .button.titlebutton:checked:hover:only-child,
 .path-bar .header-bar .button.titlebutton:checked:only-child:backdrop,
 .path-bar .header-bar .button.titlebutton:checked:hover:only-child:backdrop,
-.path-bar .header-bar .button.titlebutton:insensitive:only-child,
-.path-bar .header-bar .button.titlebutton:insensitive:only-child:backdrop,
+.path-bar .header-bar .button.titlebutton:disabled:only-child,
+.path-bar .header-bar .button.titlebutton:disabled:only-child:backdrop,
 .header-bar .path-bar .button.titlebutton:only-child,
 .header-bar .path-bar .button.titlebutton:hover:only-child,
 .header-bar .path-bar .button.titlebutton:only-child:backdrop,
@@ -3059,8 +3049,8 @@ NemoPathBar.raised.linked .button:insensitive:last-child:backdrop {
 .header-bar .path-bar .button.titlebutton:checked:hover:only-child,
 .header-bar .path-bar .button.titlebutton:checked:only-child:backdrop,
 .header-bar .path-bar .button.titlebutton:checked:hover:only-child:backdrop,
-.header-bar .path-bar .button.titlebutton:insensitive:only-child,
-.header-bar .path-bar .button.titlebutton:insensitive:only-child:backdrop,
+.header-bar .path-bar .button.titlebutton:disabled:only-child,
+.header-bar .path-bar .button.titlebutton:disabled:only-child:backdrop,
 .path-bar .titlebar .button.titlebutton:only-child,
 .path-bar .titlebar .button.titlebutton:hover:only-child,
 .path-bar .titlebar .button.titlebutton:only-child:backdrop,
@@ -3073,8 +3063,8 @@ NemoPathBar.raised.linked .button:insensitive:last-child:backdrop {
 .path-bar .titlebar .button.titlebutton:checked:hover:only-child,
 .path-bar .titlebar .button.titlebutton:checked:only-child:backdrop,
 .path-bar .titlebar .button.titlebutton:checked:hover:only-child:backdrop,
-.path-bar .titlebar .button.titlebutton:insensitive:only-child,
-.path-bar .titlebar .button.titlebutton:insensitive:only-child:backdrop,
+.path-bar .titlebar .button.titlebutton:disabled:only-child,
+.path-bar .titlebar .button.titlebutton:disabled:only-child:backdrop,
 .titlebar .path-bar .button.titlebutton:only-child,
 .titlebar .path-bar .button.titlebutton:hover:only-child,
 .titlebar .path-bar .button.titlebutton:only-child:backdrop,
@@ -3087,8 +3077,8 @@ NemoPathBar.raised.linked .button:insensitive:last-child:backdrop {
 .titlebar .path-bar .button.titlebutton:checked:hover:only-child,
 .titlebar .path-bar .button.titlebutton:checked:only-child:backdrop,
 .titlebar .path-bar .button.titlebutton:checked:hover:only-child:backdrop,
-.titlebar .path-bar .button.titlebutton:insensitive:only-child,
-.titlebar .path-bar .button.titlebutton:insensitive:only-child:backdrop,
+.titlebar .path-bar .button.titlebutton:disabled:only-child,
+.titlebar .path-bar .button.titlebutton:disabled:only-child:backdrop,
 NemoPathBar.raised.linked .button:only-child,
 NemoPathBar.raised.linked .button:hover:only-child,
 NemoPathBar.raised.linked .button:only-child:backdrop,
@@ -3101,8 +3091,8 @@ NemoPathBar.raised.linked .button:checked:only-child,
 NemoPathBar.raised.linked .button:checked:hover:only-child,
 NemoPathBar.raised.linked .button:checked:only-child:backdrop,
 NemoPathBar.raised.linked .button:checked:hover:only-child:backdrop,
-NemoPathBar.raised.linked .button:insensitive:only-child,
-NemoPathBar.raised.linked .button:insensitive:only-child:backdrop {
+NemoPathBar.raised.linked .button:disabled:only-child,
+NemoPathBar.raised.linked .button:disabled:only-child:backdrop {
     padding-left:  10px;
     padding-right: 10px;
     border-right-width: 1px;
@@ -3138,13 +3128,13 @@ GtkTreeView.view {
     box-shadow: inset 0 -1px alpha(white, 0.2), inset 0 1px alpha(black,0.8);}
   GtkTreeView.view:backdrop:selected {
     box-shadow: none;}
-  GtkTreeView.view:insensitive {
+  GtkTreeView.view:disabled {
     color: @insensitive_fg_color; }
-    GtkTreeView.view:insensitive:selected {
+    GtkTreeView.view:disabled:selected {
       color: shade(@insensitive_fg_color, 0.9); }
-      GtkTreeView.view:insensitive:selected:backdrop {
+      GtkTreeView.view:disabled:selected:backdrop {
         color: shade(@insensitive_fg_color, 1.2); }
-    GtkTreeView.view:insensitive:backdrop {
+    GtkTreeView.view:disabled:backdrop {
       color: @insensitive_fg_color; }
   GtkTreeView.view.separator:backdrop {
     color: rgba(0, 0, 0, 0.1); }
@@ -3192,14 +3182,14 @@ GtkTreeView.view {
       box-shadow: none; }
   GtkTreeView.view.trough {
     border: 1px solid alpha(black,0.4);
-    background-color: transparent;
+    background-color: #2C2C2E;
     background-image: linear-gradient(to bottom,
                                      shade(#3c3c3e, 0.9),
                                      shade(#3c3c3e, 1.2)
                                       );
     border-radius: 4px; }
     GtkTreeView.view.trough:selected {
-      background-color: transparent;
+      background-color: #2C2C2E;
     background-image: linear-gradient(to bottom,
                                      shade(#545457, 0.9),
                                      shade(#545457, 1.2)
@@ -3213,7 +3203,7 @@ column-header .button, column-header .header-bar .button.titlebutton, .header-ba
 column-header .titlebar .button.titlebutton,
 .titlebar column-header .button.titlebutton {
   color: shade(#aaaaaa, 0.8);
-  background-color: transparent;
+  background-color: #2C2C2E;
   background-image: linear-gradient(to bottom, alpha(black, 0.1), alpha(black,0.35));
   font-weight: bold;
   text-shadow: none;
@@ -3222,7 +3212,7 @@ column-header .titlebar .button.titlebutton,
   column-header .titlebar .button.titlebutton:hover,
   .titlebar column-header .button.titlebutton:hover {
     color: shade(#d2d2d2, 0.8);
-    background-color: transparent;
+    background-color: #2C2C2E;
     background-image: linear-gradient(to bottom, alpha(black, 0.35), alpha(black,0.1));
     box-shadow: none;
     transition: none; }
@@ -3230,7 +3220,7 @@ column-header .titlebar .button.titlebutton,
   column-header .titlebar .button.titlebutton:active,
   .titlebar column-header .button.titlebutton:active {
     color: #e2e2e2;
-    background-color: transparent;
+    background-color: #2C2C2E;
     background-image: linear-gradient(to bottom, alpha(black, 0.45), alpha(black,0.2));
     transition: none; }
 column-header:last-child .button, column-header:last-child .header-bar .button.titlebutton, .header-bar column-header:last-child .button.titlebutton,
@@ -3264,9 +3254,9 @@ column-header .titlebar .button.titlebutton,
                                   
 	box-shadow: none;
   text-shadow: none; }
-  column-header .button:insensitive, column-header .header-bar .button.titlebutton:insensitive, .header-bar column-header .button.titlebutton:insensitive,
-  column-header .titlebar .button.titlebutton:insensitive,
-  .titlebar column-header .button.titlebutton:insensitive {
+  column-header .button:disabled, column-header .header-bar .button.titlebutton:disabled, .header-bar column-header .button.titlebutton:disabled,
+  column-header .titlebar .button.titlebutton:disabled,
+  .titlebar column-header .button.titlebutton:disabled {
     border-color: transparent;
     background-image: none; }
   column-header .button:backdrop, column-header .header-bar .button.titlebutton:backdrop, .header-bar column-header .button.titlebutton:backdrop,
@@ -3276,7 +3266,7 @@ column-header .titlebar .button.titlebutton,
     border-style: none solid solid none;
     color: @theme_unfocused_fg_color;
     background-image: linear-gradient(to bottom, alpha(black, 0.1), alpha(black,0.2));
-    background-color: transparent; 
+    background-color: #2C2C2E; 
     box-shadow:none;
     border-image: linear-gradient(to bottom,
                                   #343436,
@@ -3290,7 +3280,7 @@ column-header .titlebar .button.titlebutton,
                                   #282829 4%,
                                   shade(#3e3e3e, 0.4)
                                   ) 0 1 1 0;}                              
-    column-header .button:backdrop:insensitive {
+    column-header .button:backdrop:disabled {
     color: #4a4a4f;
       border-color: #727272;
       background-image: none; }
@@ -3311,7 +3301,7 @@ column-header .titlebar .button.titlebutton,
       color: black; 
       font-weight: bold;
       text-shadow: 0 -1px 2px alpha(white, 0.35), 0 1px 2px alpha(white, 0.35), 0 1px alpha(white, 0.35);}
-    .menubar > .menuitem:insensitive {
+    .menubar > .menuitem:disabled {
       color: @insensitive_fg_color;
       box-shadow: none; }
 
@@ -3330,9 +3320,9 @@ column-header .titlebar .button.titlebutton,
     .menu .menuitem:hover {
       color: #eeeeee;
       background-color: shade(@theme_selected_bg_color,1.2); }
-    .menu .menuitem:insensitive {
+    .menu .menuitem:disabled {
       color: @insensitive_fg_color; }
-      .menu .menuitem:insensitive:backdrop {
+      .menu .menuitem:disabled:backdrop {
         color: @insensitive_fg_color; }
     .menu .menuitem:backdrop, .menu .menuitem:backdrop:hover {
       color: @theme_unfocused_fg_color;
@@ -3351,7 +3341,7 @@ column-header .titlebar .button.titlebutton,
       border-top: 1px solid #1c1c1e; }
     .menu.button:hover {
       background-color: #1c1c1e; }
-    .menu.button:insensitive {
+    .menu.button:disabled {
       color: transparent;
       background-color: transparent;
       border-color: transparent; }
@@ -3382,7 +3372,7 @@ column-header .titlebar .button.titlebutton,
   .popover > .search-bar,
   .popover > .location-bar, .popover.osd > .toolbar, .popover.osd > .inline-toolbar, .popover.osd > .search-bar, .popover.osd > .location-bar {
     border-style: none;
-    background-color: transparent; }
+    background-color: #2C2C2E; }
     
   .popover .button:not(.flat) { 
     border-color: black;
@@ -3464,13 +3454,6 @@ column-header .titlebar .button.titlebutton,
 .notebook {
   padding: 0;
   background-color: @theme_base_color;
-  -GtkNotebook-initial-gap: 10;
-  -GtkNotebook-arrow-spacing: 5;
-  -GtkNotebook-tab-curvature: 0;
-  -GtkNotebook-tab-overlap: -8;
-  -GtkNotebook-has-tab-gap: false;
-  -GtkWidget-focus-padding: 0;
-  -GtkWidget-focus-line-width: 0;
   transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
   .notebook:backdrop {
     background-color: shade(@theme_base_color, 1.2); }
@@ -3618,7 +3601,7 @@ column-header .titlebar .button.titlebutton,
     NautilusWindow NautilusNotebook.notebook tab.reorderable-page.top:active:hover,NautilusWindow NautilusNotebook.notebook tab.reorderable-page.top.active-page:hover,
     NemoWindow NemoNotebook.notebook tab.reorderable-page.top:active:hover, NemoWindow NemoNotebook.notebook tab.reorderable-page.top.active-page:hover {
         background-color: transparent;
-        background-image: linear-gradient(to bottom, alpha(#0f0f10,0.1)), url("assets/background-dark.png");
+        background-image: image(alpha(#0f0f10,0.1)), url("assets/background-dark.png");
         border-bottom-width: 0;
         }
         .notebook tab.reorderable-page.top:active:backdrop, .notebook tab.reorderable-page.top.active-page:backdrop {
@@ -3711,7 +3694,7 @@ column-header .titlebar .button.titlebutton,
     .titlebar .notebook tab .button.titlebutton {
       padding: 0;
       border: 1px solid transparent;
-      icon-shadow: none;
+      -gtk-icon-shadow: none;
       transition: none;
       color: @theme_unfocused_fg_color; }
       .notebook tab .button:hover {
@@ -3741,7 +3724,7 @@ column-header .titlebar .button.titlebutton,
 				0 -3px alpha(black, 0.01) inset,
 				0 1px 2px 0 rgba(0,0,0,0.2); 
     text-shadow: 0 1px rgba(0,0,0, 0.76923);
-    icon-shadow: 0 1px rgba(0,0,0, 0.76923); }
+    -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923); }
       .notebook tab .button:active {
         color: #fff;
         outline-color: rgba(46, 52, 54, 0.3);
@@ -3752,7 +3735,7 @@ column-header .titlebar .button.titlebutton,
                                       mix(shade(#3c3c3e, 1.2), @theme_selected_bg_color, 0.25));
     background-color: transparent;
     text-shadow: 0 1px rgba(0,0,0, 0.76923);
-    icon-shadow: 0 1px rgba(0,0,0, 0.76923);
+    -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923);
     box-shadow: inset 0 1px rgba(0, 0, 0, 0.07), inset 0 2px 1px -2px rgba(0, 0, 0, 0.6), 0 1px alpha(white,0.12);}
       .notebook tab .button:backdrop {
         color: rgba(141, 144, 145, 0.3);
@@ -3767,11 +3750,11 @@ column-header .titlebar .button.titlebutton,
       color: shade(@theme_fg_color, 1.2); }
     .notebook.arrow:active {
       color: #fff; }
-    .notebook.arrow:insensitive {
+    .notebook.arrow:disabled {
       color: @insensitive_fg_color; }
     .notebook.arrow:backdrop {
       color: @theme_unfocused_fg_color; }
-      .notebook.arrow:backdrop:insensitive {
+      .notebook.arrow:backdrop:disabled {
         color: #4a4a4d; }
 
 /**************
@@ -3799,7 +3782,7 @@ column-header .titlebar .button.titlebutton,
       background-clip: padding-box; }
     .scrollbar.overlay-indicator:not(.dragging):not(.hovering) .trough {
       border-style: none;
-      background-color: transparent; }
+      background-color: #2C2C2E; }
     .scrollbar.overlay-indicator:not(.dragging):not(.hovering).vertical .slider {
       margin-top: 2px;
       margin-bottom: 2px; }
@@ -3818,11 +3801,11 @@ column-header .titlebar .button.titlebutton,
     background-color: #7a7e7f; }
     .scrollbar .slider:hover {
       background-color: #54595a; }
-    .scrollbar .slider:prelight:active {
+    .scrollbar .slider:hover:active {
       background-color: alpha(white, 0.6); }
     .scrollbar .slider:backdrop {
       background-color: @theme_unfocused_fg_color; }
-    .scrollbar .slider:insensitive {
+    .scrollbar .slider:disabled {
       background-color: transparent; }
   .scrollbar .slider {
     border-radius: 100px;
@@ -3887,12 +3870,12 @@ GtkSwitch {
     color: @theme_fg_color;
     text-shadow: 0 1px rgba(0, 0, 0, 0.1); }
     GtkSwitch.trough:active {
-      background-image: linear-gradient(to bottom, @theme_selected_bg_color);
+      background-image: image(@theme_selected_bg_color);
       color: white;
       border-color: @theme_selected_bg_color;
       box-shadow: 0 1px alpha(white,0.08);
       text-shadow: 0 1px rgba(24, 68, 114, 0.5), 0 0 2px rgba(255, 255, 255, 0.6); }
-    GtkSwitch.trough:insensitive {
+    GtkSwitch.trough:disabled {
       color: @insensitive_fg_color;
       background-image: none;
       border-color: #202022;
@@ -3910,9 +3893,9 @@ GtkSwitch {
       GtkSwitch.trough:backdrop:active {
         color: white;
         border-color: shade(@theme_selected_bg_color, 1.1);
-        background-image: linear-gradient(to bottom, shade(@theme_selected_bg_color, 1.1));
+        background-image: image(shade(@theme_selected_bg_color, 1.1));
         box-shadow: none; }
-      GtkSwitch.trough:backdrop:insensitive {
+      GtkSwitch.trough:backdrop:disabled {
         color: #4a4a4d;
         background-image: none;
         background-color: #2a2a2c;
@@ -3936,7 +3919,7 @@ GtkSwitch {
                                       shade(#3c3c3e, 0.9)
                                       );     
   text-shadow: 0 -1px rgba(0,0,0,0.7);
-  icon-shadow: 0 -1px rgba(0,0,0,0.7);                                   
+  -gtk-icon-shadow: 0 -1px rgba(0,0,0,0.7);                                   
   box-shadow: 0 1px alpha(white, 0.08) inset,
 				0 2px alpha(white, 0.04) inset,
 				1px 0 alpha(white, 0.03) inset,
@@ -3962,7 +3945,7 @@ GtkSwitch {
                                       shade(#3c3c3e, 0.9)
                                       );
       text-shadow: 0 1px rgba(0,0,0, 0.76923);
-    icon-shadow: 0 1px rgba(0,0,0, 0.76923);
+    -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923);
       box-shadow: 0 1px alpha(white, 0.08) inset,
 				0 2px alpha(white, 0.04) inset,
 				1px 0 alpha(white, 0.03) inset,
@@ -3972,14 +3955,14 @@ GtkSwitch {
 				0 -3px alpha(black, 0.01) inset; }
     GtkSwitch.slider:active {
       border:1px solid @theme_selected_bg_color; }
-    GtkSwitch.slider:insensitive {
+    GtkSwitch.slider:disabled {
       color: @insensitive_fg_color;
       border:1px solid #202022;
-    background-image: linear-gradient(to bottom, #2c2c2e);
+    background-image: image(#2c2c2e);
       text-shadow: none;
-      icon-shadow: none;
+      -gtk-icon-shadow: none;
       box-shadow: inset 0 1px alpha(white,0.0), inset 0 -1px rgba(0,0,0,0.04); }
-      GtkSwitch.slider:insensitive > .label {
+      GtkSwitch.slider:disabled > .label {
         color: inherit; }
     GtkSwitch.slider:backdrop {
       color: @theme_unfocused_fg_color;
@@ -4005,18 +3988,18 @@ GtkSwitch {
 				0 -2px alpha(black, 0.01) inset,
 				0 -3px alpha(black, 0.005) inset;
       text-shadow: none;
-      icon-shadow: none; }
+      -gtk-icon-shadow: none; }
       GtkSwitch.slider:backdrop:active {
         border:1px solid shade(@theme_selected_bg_color, 1.1) }
-      GtkSwitch.slider:backdrop:insensitive {
+      GtkSwitch.slider:backdrop:disabled {
         color: #4a4a4d;
         border:1px solid #202022;
-        background-image: linear-gradient(to bottom, #2a2a2c);
+        background-image: image(#2a2a2c);
         text-shadow: none;
-        icon-shadow: none;
+        -gtk-icon-shadow: none;
         box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0);
         box-shadow: none; }
-        GtkSwitch.slider:backdrop:insensitive > .label {
+        GtkSwitch.slider:backdrop:disabled > .label {
           color: inherit; }
   .list-row:selected GtkSwitch {
     box-shadow: none;
@@ -4038,10 +4021,10 @@ GtkSwitch {
  *************************/
 .check {
   -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked.png"), url("assets/checkbox-unchecked@2.png"));
-  icon-shadow: 0 1px 0 alpha(white,0.08); }
+  -gtk-icon-shadow: 0 1px 0 alpha(white,0.08); }
   .check.button.flat, .check.sidebar-button.button, .header-bar .check.titlebutton.button,
   .titlebar .check.titlebutton.button {
-    icon-shadow: none; }
+    -gtk-icon-shadow: none; }
 
 .view.check:selected, GtkCalendar.check:selected,
 .list-row:selected .check {
@@ -4049,10 +4032,10 @@ GtkSwitch {
 
 .check:hover {
   -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked-hover.png"), url("assets/checkbox-unchecked-hover@2.png"));
-  icon-shadow: 0 1px 0 alpha(black,0.12); }
+  -gtk-icon-shadow: 0 1px 0 alpha(black,0.12); }
   .check:hover.button.flat, .check.sidebar-button.button:hover, .header-bar .check.titlebutton.button:hover,
   .titlebar .check.titlebutton.button:hover {
-    icon-shadow: none; }
+    -gtk-icon-shadow: none; }
 
 .view.check:hover:selected, GtkCalendar.check:hover:selected,
 .list-row:selected .check:hover {
@@ -4060,142 +4043,142 @@ GtkSwitch {
 
 .check:active {
   -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked-active.png"), url("assets/checkbox-unchecked-active@2.png"));
-  icon-shadow: 0 1px 0 alpha(white,0.12); }
+  -gtk-icon-shadow: 0 1px 0 alpha(white,0.12); }
   .check:active.button.flat, .check.sidebar-button.button:active, .header-bar .check.titlebutton.button:active,
   .titlebar .check.titlebutton.button:active {
-    icon-shadow: none; }
+    -gtk-icon-shadow: none; }
 
 .view.check:active:selected, GtkCalendar.check:active:selected,
 .list-row:selected .check:active {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-checkbox-unchecked-active.png"), url("assets/selected-checkbox-unchecked-active@2.png")); }
 
-.check:insensitive {
+.check:disabled {
   -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked-insensitive.png"), url("assets/checkbox-unchecked-insensitive@2.png"));
-  icon-shadow: 0 1px 0 alpha(white,0.08); }
-  .check:insensitive.button.flat, .check.sidebar-button.button:insensitive, .header-bar .check.titlebutton.button:insensitive,
-  .titlebar .check.titlebutton.button:insensitive {
-    icon-shadow: none; }
+  -gtk-icon-shadow: 0 1px 0 alpha(white,0.08); }
+  .check:disabled.button.flat, .check.sidebar-button.button:disabled, .header-bar .check.titlebutton.button:disabled,
+  .titlebar .check.titlebutton.button:disabled {
+    -gtk-icon-shadow: none; }
 
-.view.check:insensitive:selected, GtkCalendar.check:insensitive:selected,
-.list-row:selected .check:insensitive {
+.view.check:disabled:selected, GtkCalendar.check:disabled:selected,
+.list-row:selected .check:disabled {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-checkbox-unchecked-insensitive.png"), url("assets/selected-checkbox-unchecked-insensitive@2.png")); }
 
 .check:backdrop {
   -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked-backdrop.png"), url("assets/checkbox-unchecked-backdrop@2.png"));
-  icon-shadow: none; }
+  -gtk-icon-shadow: none; }
   .check:backdrop.button.flat, .check.sidebar-button.button:backdrop, .header-bar .check.titlebutton.button:backdrop,
   .titlebar .check.titlebutton.button:backdrop {
-    icon-shadow: none; }
+    -gtk-icon-shadow: none; }
 
 .view.check:backdrop:selected, GtkCalendar.check:backdrop:selected,
 .list-row:selected .check:backdrop {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-checkbox-unchecked-backdrop.png"), url("assets/selected-checkbox-unchecked-backdrop@2.png")); }
 
-.check:backdrop:insensitive {
+.check:backdrop:disabled {
   -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked-backdrop-insensitive.png"), url("assets/checkbox-unchecked-backdrop-insensitive@2.png"));
-  icon-shadow: none; }
-  .check:backdrop:insensitive.button.flat, .check.sidebar-button.button:backdrop:insensitive, .header-bar .check.titlebutton.button:backdrop:insensitive,
-  .titlebar .check.titlebutton.button:backdrop:insensitive {
-    icon-shadow: none; }
+  -gtk-icon-shadow: none; }
+  .check:backdrop:disabled.button.flat, .check.sidebar-button.button:backdrop:disabled, .header-bar .check.titlebutton.button:backdrop:disabled,
+  .titlebar .check.titlebutton.button:backdrop:disabled {
+    -gtk-icon-shadow: none; }
 
-.view.check:backdrop:insensitive:selected, GtkCalendar.check:backdrop:insensitive:selected,
-.list-row:selected .check:backdrop:insensitive {
+.view.check:backdrop:disabled:selected, GtkCalendar.check:backdrop:disabled:selected,
+.list-row:selected .check:backdrop:disabled {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-checkbox-unchecked-backdrop-insensitive.png"), url("assets/selected-checkbox-unchecked-backdrop-insensitive@2.png")); }
 
-.check:inconsistent {
+.check:indeterminate {
   -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed.png"), url("assets/checkbox-mixed@2.png"));
-  icon-shadow: 0 1px 0 alpha(white,0.12); }
-  .check:inconsistent.button.flat, .check.sidebar-button.button:inconsistent, .header-bar .check.titlebutton.button:inconsistent,
-  .titlebar .check.titlebutton.button:inconsistent {
-    icon-shadow: none; }
+  -gtk-icon-shadow: 0 1px 0 alpha(white,0.12); }
+  .check:indeterminate.button.flat, .check.sidebar-button.button:indeterminate, .header-bar .check.titlebutton.button:indeterminate,
+  .titlebar .check.titlebutton.button:indeterminate {
+    -gtk-icon-shadow: none; }
 
-.view.check:inconsistent:selected, GtkCalendar.check:inconsistent:selected,
-.list-row:selected .check:inconsistent {
+.view.check:indeterminate:selected, GtkCalendar.check:indeterminate:selected,
+.list-row:selected .check:indeterminate {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-checkbox-mixed.png"), url("assets/selected-checkbox-mixed@2.png")); }
 
-.check:inconsistent:hover {
+.check:indeterminate:hover {
   -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed-hover.png"), url("assets/checkbox-mixed-hover@2.png"));
-  icon-shadow: 0 1px 0 alpha(white,0.12); }
-  .check:inconsistent:hover.button.flat, .check.sidebar-button.button:inconsistent:hover, .header-bar .check.titlebutton.button:inconsistent:hover,
-  .titlebar .check.titlebutton.button:inconsistent:hover {
-    icon-shadow: none; }
+  -gtk-icon-shadow: 0 1px 0 alpha(white,0.12); }
+  .check:indeterminate:hover.button.flat, .check.sidebar-button.button:indeterminate:hover, .header-bar .check.titlebutton.button:indeterminate:hover,
+  .titlebar .check.titlebutton.button:indeterminate:hover {
+    -gtk-icon-shadow: none; }
 
-.view.check:inconsistent:hover:selected, GtkCalendar.check:inconsistent:hover:selected,
-.list-row:selected .check:inconsistent:hover {
+.view.check:indeterminate:hover:selected, GtkCalendar.check:indeterminate:hover:selected,
+.list-row:selected .check:indeterminate:hover {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-checkbox-mixed-hover.png"), url("assets/selected-checkbox-mixed-hover@2.png")); }
 
-.check:inconsistent:selected {
+.check:indeterminate:selected {
   -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed-active.png"), url("assets/checkbox-mixed-active@2.png"));
-  icon-shadow: 0 1px 0 alpha(white,0.08); }
-  .check:inconsistent:selected.button.flat, .check.sidebar-button.button:inconsistent:selected, .header-bar .check.titlebutton.button:inconsistent:selected,
-  .titlebar .check.titlebutton.button:inconsistent:selected {
-    icon-shadow: none; }
+  -gtk-icon-shadow: 0 1px 0 alpha(white,0.08); }
+  .check:indeterminate:selected.button.flat, .check.sidebar-button.button:indeterminate:selected, .header-bar .check.titlebutton.button:indeterminate:selected,
+  .titlebar .check.titlebutton.button:indeterminate:selected {
+    -gtk-icon-shadow: none; }
 
-.view.check:inconsistent:selected:selected, GtkCalendar.check:inconsistent:selected,
-.list-row:selected .check:inconsistent:selected {
+.view.check:indeterminate:selected:selected, GtkCalendar.check:indeterminate:selected,
+.list-row:selected .check:indeterminate:selected {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-checkbox-mixed-active.png"), url("assets/selected-checkbox-mixed-active@2.png")); }
 
-.check:inconsistent:backdrop {
+.check:indeterminate:backdrop {
   -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed-backdrop.png"), url("assets/checkbox-mixed-backdrop@2.png"));
-  icon-shadow: none; }
-  .check:inconsistent:backdrop.button.flat, .check.sidebar-button.button:inconsistent:backdrop, .header-bar .check.titlebutton.button:inconsistent:backdrop,
-  .titlebar .check.titlebutton.button:inconsistent:backdrop {
-    icon-shadow: none; }
+  -gtk-icon-shadow: none; }
+  .check:indeterminate:backdrop.button.flat, .check.sidebar-button.button:indeterminate:backdrop, .header-bar .check.titlebutton.button:indeterminate:backdrop,
+  .titlebar .check.titlebutton.button:indeterminate:backdrop {
+    -gtk-icon-shadow: none; }
 
-.view.check:inconsistent:backdrop:selected, GtkCalendar.check:inconsistent:backdrop:selected,
-.list-row:selected .check:inconsistent:backdrop {
+.view.check:indeterminate:backdrop:selected, GtkCalendar.check:indeterminate:backdrop:selected,
+.list-row:selected .check:indeterminate:backdrop {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-checkbox-mixed-backdrop.png"), url("assets/selected-checkbox-mixed-backdrop@2.png")); }
 
-.check:inconsistent:insensitive {
+.check:indeterminate:disabled {
   -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed-insensitive.png"), url("assets/checkbox-mixed-insensitive@2.png"));
-  icon-shadow: 0 1px 0 alpha(white,0.08); }
-  .check:inconsistent:insensitive.button.flat, .check.sidebar-button.button:inconsistent:insensitive, .header-bar .check.titlebutton.button:inconsistent:insensitive,
-  .titlebar .check.titlebutton.button:inconsistent:insensitive {
-    icon-shadow: none; }
+  -gtk-icon-shadow: 0 1px 0 alpha(white,0.08); }
+  .check:indeterminate:disabled.button.flat, .check.sidebar-button.button:indeterminate:disabled, .header-bar .check.titlebutton.button:indeterminate:disabled,
+  .titlebar .check.titlebutton.button:indeterminate:disabled {
+    -gtk-icon-shadow: none; }
 
-.view.check:inconsistent:insensitive:selected, GtkCalendar.check:inconsistent:insensitive:selected,
-.list-row:selected .check:inconsistent:insensitive {
+.view.check:indeterminate:disabled:selected, GtkCalendar.check:indeterminate:disabled:selected,
+.list-row:selected .check:indeterminate:disabled {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-checkbox-mixed-insensitive.png"), url("assets/selected-checkbox-mixed-insensitive@2.png")); }
 
-.check:inconsistent:insensitive:backdrop {
+.check:indeterminate:disabled:backdrop {
   -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed-backdrop-insensitive.png"), url("assets/checkbox-mixed-backdrop-insensitive@2.png"));
-  icon-shadow: none; }
-  .check:inconsistent:insensitive:backdrop.button.flat, .check.sidebar-button.button:inconsistent:insensitive:backdrop, .header-bar .check.titlebutton.button:inconsistent:insensitive:backdrop,
-  .titlebar .check.titlebutton.button:inconsistent:insensitive:backdrop {
-    icon-shadow: none; }
+  -gtk-icon-shadow: none; }
+  .check:indeterminate:disabled:backdrop.button.flat, .check.sidebar-button.button:indeterminate:disabled:backdrop, .header-bar .check.titlebutton.button:indeterminate:disabled:backdrop,
+  .titlebar .check.titlebutton.button:indeterminate:disabled:backdrop {
+    -gtk-icon-shadow: none; }
 
-.view.check:inconsistent:insensitive:backdrop:selected, GtkCalendar.check:inconsistent:insensitive:backdrop:selected,
-.list-row:selected .check:inconsistent:insensitive:backdrop {
+.view.check:indeterminate:disabled:backdrop:selected, GtkCalendar.check:indeterminate:disabled:backdrop:selected,
+.list-row:selected .check:indeterminate:disabled:backdrop {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-checkbox-mixed-backdrop-insensitive.png"), url("assets/selected-checkbox-mixed-backdrop-insensitive@2.png")); }
 
 .check:checked {
   -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked.png"), url("assets/checkbox-checked@2.png"));
-  icon-shadow: 0 1px 0 alpha(white,0.12); }
+  -gtk-icon-shadow: 0 1px 0 alpha(white,0.12); }
   .check:checked.button.flat, .check.sidebar-button.button:checked, .header-bar .check.titlebutton.button:checked,
   .titlebar .check.titlebutton.button:checked {
-    icon-shadow: none; }
+    -gtk-icon-shadow: none; }
 
 .view.check:checked:selected, GtkCalendar.check:checked:selected,
 .list-row:selected .check:checked {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-checkbox-checked.png"), url("assets/selected-checkbox-checked@2.png")); }
 
-.check:checked:insensitive {
+.check:checked:disabled {
   -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-insensitive.png"), url("assets/checkbox-checked-insensitive@2.png"));
-  icon-shadow: 0 1px 0 alpha(white,0.08); }
-  .check:checked:insensitive.button.flat, .check.sidebar-button.button:checked:insensitive, .header-bar .check.titlebutton.button:checked:insensitive,
-  .titlebar .check.titlebutton.button:checked:insensitive {
-    icon-shadow: none; }
+  -gtk-icon-shadow: 0 1px 0 alpha(white,0.08); }
+  .check:checked:disabled.button.flat, .check.sidebar-button.button:checked:disabled, .header-bar .check.titlebutton.button:checked:disabled,
+  .titlebar .check.titlebutton.button:checked:disabled {
+    -gtk-icon-shadow: none; }
 
-.view.check:checked:insensitive:selected, GtkCalendar.check:checked:insensitive:selected,
-.list-row:selected .check:checked:insensitive {
+.view.check:checked:disabled:selected, GtkCalendar.check:checked:disabled:selected,
+.list-row:selected .check:checked:disabled {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-checkbox-checked-insensitive.png"), url("assets/selected-checkbox-checked-insensitive@2.png")); }
 
 .check:checked:hover {
   -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-hover.png"), url("assets/checkbox-checked-hover@2.png"));
-  icon-shadow: 0 1px 0 alpha(white,0.12); }
+  -gtk-icon-shadow: 0 1px 0 alpha(white,0.12); }
   .check:checked:hover.button.flat, .check.sidebar-button.button:checked:hover, .header-bar .check.titlebutton.button:checked:hover,
   .titlebar .check.titlebutton.button:checked:hover {
-    icon-shadow: none; }
+    -gtk-icon-shadow: none; }
 
 .view.check:checked:hover:selected, GtkCalendar.check:checked:hover:selected,
 .list-row:selected .check:checked:hover {
@@ -4203,10 +4186,10 @@ GtkSwitch {
 
 .check:checked:active {
   -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-active.png"), url("assets/checkbox-checked-active@2.png"));
-  icon-shadow: 0 1px 0 alpha(white,0.08); }
+  -gtk-icon-shadow: 0 1px 0 alpha(white,0.08); }
   .check:checked:active.button.flat, .check.sidebar-button.button:checked:active, .header-bar .check.titlebutton.button:checked:active,
   .titlebar .check.titlebutton.button:checked:active {
-    icon-shadow: none; }
+    -gtk-icon-shadow: none; }
 
 .view.check:checked:active:selected, GtkCalendar.check:checked:active:selected,
 .list-row:selected .check:checked:active {
@@ -4214,45 +4197,45 @@ GtkSwitch {
 
 .check:backdrop:checked {
   -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-backdrop.png"), url("assets/checkbox-checked-backdrop@2.png"));
-  icon-shadow: none; }
+  -gtk-icon-shadow: none; }
   .check:backdrop:checked.button.flat, .check.sidebar-button.button:backdrop:checked, .header-bar .check.titlebutton.button:backdrop:checked,
   .titlebar .check.titlebutton.button:backdrop:checked {
-    icon-shadow: none; }
+    -gtk-icon-shadow: none; }
 
 .view.check:backdrop:checked:selected, GtkCalendar.check:backdrop:checked:selected,
 .list-row:selected .check:backdrop:checked {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-checkbox-checked-backdrop.png"), url("assets/selected-checkbox-checked-backdrop@2.png")); }
 
-.check:backdrop:checked:insensitive {
+.check:backdrop:checked:disabled {
   -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-backdrop-insensitive.png"), url("assets/checkbox-checked-backdrop-insensitive@2.png"));
-  icon-shadow: none; }
-  .check:backdrop:checked:insensitive.button.flat, .check.sidebar-button.button:backdrop:checked:insensitive, .header-bar .check.titlebutton.button:backdrop:checked:insensitive,
-  .titlebar .check.titlebutton.button:backdrop:checked:insensitive {
-    icon-shadow: none; }
+  -gtk-icon-shadow: none; }
+  .check:backdrop:checked:disabled.button.flat, .check.sidebar-button.button:backdrop:checked:disabled, .header-bar .check.titlebutton.button:backdrop:checked:disabled,
+  .titlebar .check.titlebutton.button:backdrop:checked:disabled {
+    -gtk-icon-shadow: none; }
 
-.view.check:backdrop:checked:insensitive:selected, GtkCalendar.check:backdrop:checked:insensitive:selected,
-.list-row:selected .check:backdrop:checked:insensitive {
+.view.check:backdrop:checked:disabled:selected, GtkCalendar.check:backdrop:checked:disabled:selected,
+.list-row:selected .check:backdrop:checked:disabled {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-checkbox-checked-backdrop-insensitive.png"), url("assets/selected-checkbox-checked-backdrop-insensitive@2.png")); }
 
 .menu .menuitem.check {
   -gtk-icon-source: -gtk-icontheme("checkbox-symbolic");
   color: #adadaf;
-  icon-shadow: none; }
+  -gtk-icon-shadow: none; }
   .menu .menuitem.check:active, .menu .menuitem.check:checked {
     -gtk-icon-source: -gtk-icontheme("checkbox-checked-symbolic"); }
-  .menu .menuitem.check:inconsistent {
+  .menu .menuitem.check:indeterminate {
     -gtk-icon-source: -gtk-icontheme("checkbox-mixed-symbolic"); }
   .menu .menuitem.check:hover {
     color: #ffffff; }
-  .menu .menuitem.check:insensitive {
+  .menu .menuitem.check:disabled {
     color: #5a5a5d; }
 
 .radio {
   -gtk-icon-source: -gtk-scaled(url("assets/radio-unchecked.png"), url("assets/radio-unchecked@2.png"));
-  icon-shadow: 0 1px 0 alpha(white,0.08); }
+  -gtk-icon-shadow: 0 1px 0 alpha(white,0.08); }
   .radio.button.flat, .radio.sidebar-button.button, .header-bar .radio.titlebutton.button,
   .titlebar .radio.titlebutton.button {
-    icon-shadow: none; }
+    -gtk-icon-shadow: none; }
 
 .view.radio:selected, GtkCalendar.radio:selected,
 .list-row:selected .radio {
@@ -4260,10 +4243,10 @@ GtkSwitch {
 
 .radio:hover {
   -gtk-icon-source: -gtk-scaled(url("assets/radio-unchecked-hover.png"), url("assets/radio-unchecked-hover@2.png"));
-  icon-shadow: 0 1px 0 alpha(black,0.12); }
+  -gtk-icon-shadow: 0 1px 0 alpha(black,0.12); }
   .radio:hover.button.flat, .radio.sidebar-button.button:hover, .header-bar .radio.titlebutton.button:hover,
   .titlebar .radio.titlebutton.button:hover {
-    icon-shadow: none; }
+    -gtk-icon-shadow: none; }
 
 .view.radio:hover:selected, GtkCalendar.radio:hover:selected,
 .list-row:selected .radio:hover {
@@ -4271,142 +4254,142 @@ GtkSwitch {
 
 .radio:active {
   -gtk-icon-source: -gtk-scaled(url("assets/radio-unchecked-active.png"), url("assets/radio-unchecked-active@2.png"));
-  icon-shadow: 0 1px 0 alpha(white,0.08); }
+  -gtk-icon-shadow: 0 1px 0 alpha(white,0.08); }
   .radio:active.button.flat, .radio.sidebar-button.button:active, .header-bar .radio.titlebutton.button:active,
   .titlebar .radio.titlebutton.button:active {
-    icon-shadow: none; }
+    -gtk-icon-shadow: none; }
 
 .view.radio:active:selected, GtkCalendar.radio:active:selected,
 .list-row:selected .radio:active {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-radio-unchecked-active.png"), url("assets/selected-radio-unchecked-active@2.png")); }
 
-.radio:insensitive {
+.radio:disabled {
   -gtk-icon-source: -gtk-scaled(url("assets/radio-unchecked-insensitive.png"), url("assets/radio-unchecked-insensitive@2.png"));
-  icon-shadow: 0 1px 0 alpha(white,0.08); }
-  .radio:insensitive.button.flat, .radio.sidebar-button.button:insensitive, .header-bar .radio.titlebutton.button:insensitive,
-  .titlebar .radio.titlebutton.button:insensitive {
-    icon-shadow: none; }
+  -gtk-icon-shadow: 0 1px 0 alpha(white,0.08); }
+  .radio:disabled.button.flat, .radio.sidebar-button.button:disabled, .header-bar .radio.titlebutton.button:disabled,
+  .titlebar .radio.titlebutton.button:disabled {
+    -gtk-icon-shadow: none; }
 
-.view.radio:insensitive:selected, GtkCalendar.radio:insensitive:selected,
-.list-row:selected .radio:insensitive {
+.view.radio:disabled:selected, GtkCalendar.radio:disabled:selected,
+.list-row:selected .radio:disabled {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-radio-unchecked-insensitive.png"), url("assets/selected-radio-unchecked-insensitive@2.png")); }
 
 .radio:backdrop {
   -gtk-icon-source: -gtk-scaled(url("assets/radio-unchecked-backdrop.png"), url("assets/radio-unchecked-backdrop@2.png"));
-  icon-shadow: none; }
+  -gtk-icon-shadow: none; }
   .radio:backdrop.button.flat, .radio.sidebar-button.button:backdrop, .header-bar .radio.titlebutton.button:backdrop,
   .titlebar .radio.titlebutton.button:backdrop {
-    icon-shadow: none; }
+    -gtk-icon-shadow: none; }
 
 .view.radio:backdrop:selected, GtkCalendar.radio:backdrop:selected,
 .list-row:selected .radio:backdrop {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-radio-unchecked-backdrop.png"), url("assets/selected-radio-unchecked-backdrop@2.png")); }
 
-.radio:backdrop:insensitive {
+.radio:backdrop:disabled {
   -gtk-icon-source: -gtk-scaled(url("assets/radio-unchecked-backdrop-insensitive.png"), url("assets/radio-unchecked-backdrop-insensitive@2.png"));
-  icon-shadow: none; }
-  .radio:backdrop:insensitive.button.flat, .radio.sidebar-button.button:backdrop:insensitive, .header-bar .radio.titlebutton.button:backdrop:insensitive,
-  .titlebar .radio.titlebutton.button:backdrop:insensitive {
-    icon-shadow: none; }
+  -gtk-icon-shadow: none; }
+  .radio:backdrop:disabled.button.flat, .radio.sidebar-button.button:backdrop:disabled, .header-bar .radio.titlebutton.button:backdrop:disabled,
+  .titlebar .radio.titlebutton.button:backdrop:disabled {
+    -gtk-icon-shadow: none; }
 
-.view.radio:backdrop:insensitive:selected, GtkCalendar.radio:backdrop:insensitive:selected,
-.list-row:selected .radio:backdrop:insensitive {
+.view.radio:backdrop:disabled:selected, GtkCalendar.radio:backdrop:disabled:selected,
+.list-row:selected .radio:backdrop:disabled {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-radio-unchecked-backdrop-insensitive.png"), url("assets/selected-radio-unchecked-backdrop-insensitive@2.png")); }
 
-.radio:inconsistent {
+.radio:indeterminate {
   -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed.png"), url("assets/radio-mixed@2.png"));
-  icon-shadow: 0 1px 0 alpha(white,0.12); }
-  .radio:inconsistent.button.flat, .radio.sidebar-button.button:inconsistent, .header-bar .radio.titlebutton.button:inconsistent,
-  .titlebar .radio.titlebutton.button:inconsistent {
-    icon-shadow: none; }
+  -gtk-icon-shadow: 0 1px 0 alpha(white,0.12); }
+  .radio:indeterminate.button.flat, .radio.sidebar-button.button:indeterminate, .header-bar .radio.titlebutton.button:indeterminate,
+  .titlebar .radio.titlebutton.button:indeterminate {
+    -gtk-icon-shadow: none; }
 
-.view.radio:inconsistent:selected, GtkCalendar.radio:inconsistent:selected,
-.list-row:selected .radio:inconsistent {
+.view.radio:indeterminate:selected, GtkCalendar.radio:indeterminate:selected,
+.list-row:selected .radio:indeterminate {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-radio-mixed.png"), url("assets/selected-radio-mixed@2.png")); }
 
-.radio:inconsistent:hover {
+.radio:indeterminate:hover {
   -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed-hover.png"), url("assets/radio-mixed-hover@2.png"));
-  icon-shadow: 0 1px 0 alpha(white,0.08); }
-  .radio:inconsistent:hover.button.flat, .radio.sidebar-button.button:inconsistent:hover, .header-bar .radio.titlebutton.button:inconsistent:hover,
-  .titlebar .radio.titlebutton.button:inconsistent:hover {
-    icon-shadow: none; }
+  -gtk-icon-shadow: 0 1px 0 alpha(white,0.08); }
+  .radio:indeterminate:hover.button.flat, .radio.sidebar-button.button:indeterminate:hover, .header-bar .radio.titlebutton.button:indeterminate:hover,
+  .titlebar .radio.titlebutton.button:indeterminate:hover {
+    -gtk-icon-shadow: none; }
 
-.view.radio:inconsistent:hover:selected, GtkCalendar.radio:inconsistent:hover:selected,
-.list-row:selected .radio:inconsistent:hover {
+.view.radio:indeterminate:hover:selected, GtkCalendar.radio:indeterminate:hover:selected,
+.list-row:selected .radio:indeterminate:hover {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-radio-mixed-hover.png"), url("assets/selected-radio-mixed-hover@2.png")); }
 
-.radio:inconsistent:selected {
+.radio:indeterminate:selected {
   -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed-active.png"), url("assets/radio-mixed-active@2.png"));
-  icon-shadow: 0 1px 0 alpha(white,0.08); }
-  .radio:inconsistent:selected.button.flat, .radio.sidebar-button.button:inconsistent:selected, .header-bar .radio.titlebutton.button:inconsistent:selected,
-  .titlebar .radio.titlebutton.button:inconsistent:selected {
-    icon-shadow: none; }
+  -gtk-icon-shadow: 0 1px 0 alpha(white,0.08); }
+  .radio:indeterminate:selected.button.flat, .radio.sidebar-button.button:indeterminate:selected, .header-bar .radio.titlebutton.button:indeterminate:selected,
+  .titlebar .radio.titlebutton.button:indeterminate:selected {
+    -gtk-icon-shadow: none; }
 
-.view.radio:inconsistent:selected:selected, GtkCalendar.radio:inconsistent:selected,
-.list-row:selected .radio:inconsistent:selected {
+.view.radio:indeterminate:selected:selected, GtkCalendar.radio:indeterminate:selected,
+.list-row:selected .radio:indeterminate:selected {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-radio-mixed-active.png"), url("assets/selected-radio-mixed-active@2.png")); }
 
-.radio:inconsistent:backdrop {
+.radio:indeterminate:backdrop {
   -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed-backdrop.png"), url("assets/radio-mixed-backdrop@2.png"));
-  icon-shadow: none; }
-  .radio:inconsistent:backdrop.button.flat, .radio.sidebar-button.button:inconsistent:backdrop, .header-bar .radio.titlebutton.button:inconsistent:backdrop,
-  .titlebar .radio.titlebutton.button:inconsistent:backdrop {
-    icon-shadow: none; }
+  -gtk-icon-shadow: none; }
+  .radio:indeterminate:backdrop.button.flat, .radio.sidebar-button.button:indeterminate:backdrop, .header-bar .radio.titlebutton.button:indeterminate:backdrop,
+  .titlebar .radio.titlebutton.button:indeterminate:backdrop {
+    -gtk-icon-shadow: none; }
 
-.view.radio:inconsistent:backdrop:selected, GtkCalendar.radio:inconsistent:backdrop:selected,
-.list-row:selected .radio:inconsistent:backdrop {
+.view.radio:indeterminate:backdrop:selected, GtkCalendar.radio:indeterminate:backdrop:selected,
+.list-row:selected .radio:indeterminate:backdrop {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-radio-mixed-backdrop.png"), url("assets/selected-radio-mixed-backdrop@2.png")); }
 
-.radio:inconsistent:insensitive {
+.radio:indeterminate:disabled {
   -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed-insensitive.png"), url("assets/radio-mixed-insensitive@2.png"));
-  icon-shadow: 0 1px 0 alpha(white,0.08); }
-  .radio:inconsistent:insensitive.button.flat, .radio.sidebar-button.button:inconsistent:insensitive, .header-bar .radio.titlebutton.button:inconsistent:insensitive,
-  .titlebar .radio.titlebutton.button:inconsistent:insensitive {
-    icon-shadow: none; }
+  -gtk-icon-shadow: 0 1px 0 alpha(white,0.08); }
+  .radio:indeterminate:disabled.button.flat, .radio.sidebar-button.button:indeterminate:disabled, .header-bar .radio.titlebutton.button:indeterminate:disabled,
+  .titlebar .radio.titlebutton.button:indeterminate:disabled {
+    -gtk-icon-shadow: none; }
 
-.view.radio:inconsistent:insensitive:selected, GtkCalendar.radio:inconsistent:insensitive:selected,
-.list-row:selected .radio:inconsistent:insensitive {
+.view.radio:indeterminate:disabled:selected, GtkCalendar.radio:indeterminate:disabled:selected,
+.list-row:selected .radio:indeterminate:disabled {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-radio-mixed-insensitive.png"), url("assets/selected-radio-mixed-insensitive@2.png")); }
 
-.radio:inconsistent:insensitive:backdrop {
+.radio:indeterminate:disabled:backdrop {
   -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed-backdrop-insensitive.png"), url("assets/radio-mixed-backdrop-insensitive@2.png"));
-  icon-shadow: none; }
-  .radio:inconsistent:insensitive:backdrop.button.flat, .radio.sidebar-button.button:inconsistent:insensitive:backdrop, .header-bar .radio.titlebutton.button:inconsistent:insensitive:backdrop,
-  .titlebar .radio.titlebutton.button:inconsistent:insensitive:backdrop {
-    icon-shadow: none; }
+  -gtk-icon-shadow: none; }
+  .radio:indeterminate:disabled:backdrop.button.flat, .radio.sidebar-button.button:indeterminate:disabled:backdrop, .header-bar .radio.titlebutton.button:indeterminate:disabled:backdrop,
+  .titlebar .radio.titlebutton.button:indeterminate:disabled:backdrop {
+    -gtk-icon-shadow: none; }
 
-.view.radio:inconsistent:insensitive:backdrop:selected, GtkCalendar.radio:inconsistent:insensitive:backdrop:selected,
-.list-row:selected .radio:inconsistent:insensitive:backdrop {
+.view.radio:indeterminate:disabled:backdrop:selected, GtkCalendar.radio:indeterminate:disabled:backdrop:selected,
+.list-row:selected .radio:indeterminate:disabled:backdrop {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-radio-mixed-backdrop-insensitive.png"), url("assets/selected-radio-mixed-backdrop-insensitive@2.png")); }
 
 .radio:checked {
   -gtk-icon-source: -gtk-scaled(url("assets/radio-checked.png"), url("assets/radio-checked@2.png"));
-  icon-shadow: 0 1px 0 alpha(white,0.12); }
+  -gtk-icon-shadow: 0 1px 0 alpha(white,0.12); }
   .radio:checked.button.flat, .radio.sidebar-button.button:checked, .header-bar .radio.titlebutton.button:checked,
   .titlebar .radio.titlebutton.button:checked {
-    icon-shadow: none; }
+    -gtk-icon-shadow: none; }
 
 .view.radio:checked:selected, GtkCalendar.radio:checked:selected,
 .list-row:selected .radio:checked {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-radio-checked.png"), url("assets/selected-radio-checked@2.png")); }
 
-.radio:checked:insensitive {
+.radio:checked:disabled {
   -gtk-icon-source: -gtk-scaled(url("assets/radio-checked-insensitive.png"), url("assets/radio-checked-insensitive@2.png"));
-  icon-shadow: 0 1px 0 alpha(white,0.08); }
-  .radio:checked:insensitive.button.flat, .radio.sidebar-button.button:checked:insensitive, .header-bar .radio.titlebutton.button:checked:insensitive,
-  .titlebar .radio.titlebutton.button:checked:insensitive {
-    icon-shadow: none; }
+  -gtk-icon-shadow: 0 1px 0 alpha(white,0.08); }
+  .radio:checked:disabled.button.flat, .radio.sidebar-button.button:checked:disabled, .header-bar .radio.titlebutton.button:checked:disabled,
+  .titlebar .radio.titlebutton.button:checked:disabled {
+    -gtk-icon-shadow: none; }
 
-.view.radio:checked:insensitive:selected, GtkCalendar.radio:checked:insensitive:selected,
-.list-row:selected .radio:checked:insensitive {
+.view.radio:checked:disabled:selected, GtkCalendar.radio:checked:disabled:selected,
+.list-row:selected .radio:checked:disabled {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-radio-checked-insensitive.png"), url("assets/selected-radio-checked-insensitive@2.png")); }
 
 .radio:checked:hover {
   -gtk-icon-source: -gtk-scaled(url("assets/radio-checked-hover.png"), url("assets/radio-checked-hover@2.png"));
-  icon-shadow: 0 1px 0 alpha(white,0.08); }
+  -gtk-icon-shadow: 0 1px 0 alpha(white,0.08); }
   .radio:checked:hover.button.flat, .radio.sidebar-button.button:checked:hover, .header-bar .radio.titlebutton.button:checked:hover,
   .titlebar .radio.titlebutton.button:checked:hover {
-    icon-shadow: none; }
+    -gtk-icon-shadow: none; }
 
 .view.radio:checked:hover:selected, GtkCalendar.radio:checked:hover:selected,
 .list-row:selected .radio:checked:hover {
@@ -4414,10 +4397,10 @@ GtkSwitch {
 
 .radio:checked:active {
   -gtk-icon-source: -gtk-scaled(url("assets/radio-checked-active.png"), url("assets/radio-checked-active@2.png"));
-  icon-shadow: 0 1px 0 alpha(white,0.08); }
+  -gtk-icon-shadow: 0 1px 0 alpha(white,0.08); }
   .radio:checked:active.button.flat, .radio.sidebar-button.button:checked:active, .header-bar .radio.titlebutton.button:checked:active,
   .titlebar .radio.titlebutton.button:checked:active {
-    icon-shadow: none; }
+    -gtk-icon-shadow: none; }
 
 .view.radio:checked:active:selected, GtkCalendar.radio:checked:active:selected,
 .list-row:selected .radio:checked:active {
@@ -4425,93 +4408,93 @@ GtkSwitch {
 
 .radio:backdrop:checked {
   -gtk-icon-source: -gtk-scaled(url("assets/radio-checked-backdrop.png"), url("assets/radio-checked-backdrop@2.png"));
-  icon-shadow: none; }
+  -gtk-icon-shadow: none; }
   .radio:backdrop:checked.button.flat, .radio.sidebar-button.button:backdrop:checked, .header-bar .radio.titlebutton.button:backdrop:checked,
   .titlebar .radio.titlebutton.button:backdrop:checked {
-    icon-shadow: none; }
+    -gtk-icon-shadow: none; }
 
 .view.radio:backdrop:checked:selected, GtkCalendar.radio:backdrop:checked:selected,
 .list-row:selected .radio:backdrop:checked {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-radio-checked-backdrop.png"), url("assets/selected-radio-checked-backdrop@2.png")); }
 
-.radio:backdrop:checked:insensitive {
+.radio:backdrop:checked:disabled {
   -gtk-icon-source: -gtk-scaled(url("assets/radio-checked-backdrop-insensitive.png"), url("assets/radio-checked-backdrop-insensitive@2.png"));
-  icon-shadow: none; }
-  .radio:backdrop:checked:insensitive.button.flat, .radio.sidebar-button.button:backdrop:checked:insensitive, .header-bar .radio.titlebutton.button:backdrop:checked:insensitive,
-  .titlebar .radio.titlebutton.button:backdrop:checked:insensitive {
-    icon-shadow: none; }
+  -gtk-icon-shadow: none; }
+  .radio:backdrop:checked:disabled.button.flat, .radio.sidebar-button.button:backdrop:checked:disabled, .header-bar .radio.titlebutton.button:backdrop:checked:disabled,
+  .titlebar .radio.titlebutton.button:backdrop:checked:disabled {
+    -gtk-icon-shadow: none; }
 
-.view.radio:backdrop:checked:insensitive:selected, GtkCalendar.radio:backdrop:checked:insensitive:selected,
-.list-row:selected .radio:backdrop:checked:insensitive {
+.view.radio:backdrop:checked:disabled:selected, GtkCalendar.radio:backdrop:checked:disabled:selected,
+.list-row:selected .radio:backdrop:checked:disabled {
   -gtk-icon-source: -gtk-scaled(url("assets/selected-radio-checked-backdrop-insensitive.png"), url("assets/selected-radio-checked-backdrop-insensitive@2.png")); }
 
 .menu .menuitem.radio {
   -gtk-icon-source: -gtk-icontheme("radio-symbolic");
   color: #adadaf;
-  icon-shadow: none; }
+  -gtk-icon-shadow: none; }
   .menu .menuitem.radio:active, .menu .menuitem.radio:checked {
     -gtk-icon-source: -gtk-icontheme("radio-checked-symbolic"); }
-  .menu .menuitem.radio:inconsistent {
+  .menu .menuitem.radio:indeterminate {
     -gtk-icon-source: -gtk-icontheme("radio-mixed-symbolic"); }
   .menu .menuitem.radio:hover {
     color: #ffffff; }
-  .menu .menuitem.radio:insensitive {
+  .menu .menuitem.radio:disabled {
     color: #5a5a5d; }
 
 .view.check, .view.radio,
 .list-row .check, list-row .radio {
-  icon-shadow: none; }
+  -gtk-icon-shadow: none; }
   .view.check:selected, GtkCalendar.check:selected, .view.check:hover, .view.radio:selected, GtkCalendar.radio:selected, .view.radio:hover,
   .list-row .check:selected,
   .list-row .check:hover, list-row .radio:selected, list-row .radio:hover {
-    icon-shadow: none; }
+    -gtk-icon-shadow: none; }
 
 .view.content-view.check:not(.list) {
-  icon-shadow: none;
+  -gtk-icon-shadow: none;
   -gtk-icon-source: -gtk-scaled(url("assets/checkbox-selectionmode.png"), url("assets/checkbox-selectionmode@2.png"));
   background-color: transparent; }
 
 .view.content-view.check:hover:not(.list) {
-  icon-shadow: none;
+  -gtk-icon-shadow: none;
   -gtk-icon-source: -gtk-scaled(url("assets/checkbox-hover-selectionmode.png"), url("assets/checkbox-hover-selectionmode@2.png"));
-  background-color: transparent; }
+  background-color: #2C2C2E; }
 
 .view.content-view.check:active:not(.list) {
-  icon-shadow: none;
+  -gtk-icon-shadow: none;
   -gtk-icon-source: -gtk-scaled(url("assets/checkbox-active-selectionmode.png"), url("assets/checkbox-active-selectionmode@2.png"));
-  background-color: transparent; }
+  background-color: #2C2C2E; }
 
 .view.content-view.check:backdrop:not(.list) {
-  icon-shadow: none;
+  -gtk-icon-shadow: none;
   -gtk-icon-source: -gtk-scaled(url("assets/checkbox-backdrop-selectionmode.png"), url("assets/checkbox-backdrop-selectionmode@2.png"));
-  background-color: transparent; }
+  background-color: #2C2C2E; }
 
 .view.content-view.check:checked:not(.list) {
-  icon-shadow: none;
+  -gtk-icon-shadow: none;
   -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-selectionmode.png"), url("assets/checkbox-checked-selectionmode@2.png"));
   background-color: transparent; }
 
 .view.content-view.check:checked:hover:not(.list) {
-  icon-shadow: none;
+  -gtk-icon-shadow: none;
   -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-hover-selectionmode.png"), url("assets/checkbox-checked-hover-selectionmode@2.png"));
-  background-color: transparent; }
+  background-color: #2C2C2E; }
 
 .view.content-view.check:checked:active:not(.list) {
-  icon-shadow: none;
+  -gtk-icon-shadow: none;
   -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-active-selectionmode.png"), url("assets/checkbox-checked-active-selectionmode@2.png"));
-  background-color: transparent; }
+  background-color: #2C2C2E; }
 
 .view.content-view.check:backdrop:checked:not(.list) {
-  icon-shadow: none;
+  -gtk-icon-shadow: none;
   -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-backdrop-selectionmode.png"), url("assets/checkbox-checked-backdrop-selectionmode@2.png"));
   background-color: transparent; }
 
 GtkCheckButton.text-button, GtkRadioButton.text-button {
   padding: 1px 2px 4px;
   outline-offset: 0; }
-  GtkCheckButton.text-button:insensitive, GtkCheckButton.text-button:insensitive:active, GtkCheckButton.text-button:insensitive:inconsistent, GtkRadioButton.text-button:insensitive, GtkRadioButton.text-button:insensitive:active, GtkRadioButton.text-button:insensitive:inconsistent {
+  GtkCheckButton.text-button:disabled, GtkCheckButton.text-button:disabled:active, GtkCheckButton.text-button:disabled:indeterminate, GtkRadioButton.text-button:disabled, GtkRadioButton.text-button:disabled:active, GtkRadioButton.text-button:disabled:indeterminate {
     color: @insensitive_fg_color; }
-    GtkCheckButton.text-button:insensitive:backdrop, GtkCheckButton.text-button:insensitive:active:backdrop, GtkCheckButton.text-button:insensitive:inconsistent:backdrop, GtkRadioButton.text-button:insensitive:backdrop, GtkRadioButton.text-button:insensitive:active:backdrop, GtkRadioButton.text-button:insensitive:inconsistent:backdrop {
+    GtkCheckButton.text-button:disabled:backdrop, GtkCheckButton.text-button:disabled:active:backdrop, GtkCheckButton.text-button:disabled:indeterminate:backdrop, GtkRadioButton.text-button:disabled:backdrop, GtkRadioButton.text-button:disabled:active:backdrop, GtkRadioButton.text-button:disabled:indeterminate:backdrop {
       color: #4a4a4d; }
 
 /************
@@ -4524,21 +4507,21 @@ GtkCheckButton.text-button, GtkRadioButton.text-button {
   -GtkRange-slider-width: 20;
   -GtkRange-trough-border: 2;
   outline-offset: -9px;
-  outline-radius: 4px; }
+  -gtk-outline-radius: 4px; }
   .scale.fine-tune,
   .scale.scale-has-marks-above.scale-has-marks-below.fine-tune,
   .scale.vertical.scale-has-marks-above.scale-has-marks-below.fine-tune {
     outline-offset: -7px;
-    outline-radius: 6px; }
+    -gtk-outline-radius: 6px; }
     .scale.fine-tune.trough,
     .scale.scale-has-marks-above.scale-has-marks-below.fine-tune.trough,
     .scale.vertical.scale-has-marks-above.scale-has-marks-below.fine-tune.trough {
       margin: 8px;
       border-radius: 4px; }
 
-      .scale.slider:backdrop:insensitive > .label,
-      .scale.scale-has-marks-above.scale-has-marks-below.slider:backdrop:insensitive > .label,
-      .scale.vertical.scale-has-marks-above.scale-has-marks-below.slider:backdrop:insensitive > .label {
+      .scale.slider:backdrop:disabled > .label,
+      .scale.scale-has-marks-above.scale-has-marks-below.slider:backdrop:disabled > .label,
+      .scale.vertical.scale-has-marks-above.scale-has-marks-below.slider:backdrop:disabled > .label {
         color: inherit; }
     
 .osd
@@ -4546,11 +4529,11 @@ GtkCheckButton.text-button, GtkRadioButton.text-button {
     .scale.vertical.scale-has-marks-above.scale-has-marks-below.slider {
       color: #eeeeec;
       border-color: rgba(0, 0, 0, 0.7);
-      background-image: linear-gradient(to bottom, rgba(32, 37, 38, 0.7));
+      background-image: image(rgba(32, 37, 38, 0.7));
       background-clip: padding-box;
       box-shadow: inset 0 1px rgba(255, 255, 255, 0.1);
       text-shadow: 0 1px black;
-      icon-shadow: 0 1px black;
+      -gtk-icon-shadow: 0 1px black;
       outline-color: rgba(238, 238, 236, 0.3);
       background-color: #202526; }
 .osd
@@ -4558,33 +4541,33 @@ GtkCheckButton.text-button, GtkRadioButton.text-button {
       .scale.vertical.scale-has-marks-above.scale-has-marks-below.slider:hover {
         color: white;
         border-color: rgba(0, 0, 0, 0.7);
-        background-image: linear-gradient(to bottom, rgba(60, 69, 71, 0.7));
+        background-image: image(rgba(60, 69, 71, 0.7));
         background-clip: padding-box;
         box-shadow: inset 0 1px rgba(255, 255, 255, 0.1);
         text-shadow: 0 1px black;
-        icon-shadow: 0 1px black;
+        -gtk-icon-shadow: 0 1px black;
         outline-color: rgba(238, 238, 236, 0.3); }
 .osd
       .scale.scale-has-marks-above.scale-has-marks-below.slider:active, .osd
       .scale.vertical.scale-has-marks-above.scale-has-marks-below.slider:active {
         color: white;
         border-color: rgba(0, 0, 0, 0.7);
-        background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.7));
+        background-image: image(rgba(0, 0, 0, 0.7));
         background-clip: padding-box;
         box-shadow: none;
         text-shadow: none;
-        icon-shadow: none;
+        -gtk-icon-shadow: none;
         outline-color: rgba(238, 238, 236, 0.3); }
 .osd
       .scale.scale-has-marks-above.scale-has-marks-below.slider:backdrop, .osd
       .scale.vertical.scale-has-marks-above.scale-has-marks-below.slider:backdrop {
         color: #eeeeec;
         border-color: rgba(0, 0, 0, 0.7);
-        background-image: linear-gradient(to bottom, rgba(32, 37, 38, 0.7));
+        background-image: image(rgba(32, 37, 38, 0.7));
         background-clip: padding-box;
         box-shadow: none;
         text-shadow: none;
-        icon-shadow: none; }
+        -gtk-icon-shadow: none; }
       
   .scale.slider, .osd .scale.slider,
   .scale.scale-has-marks-above.scale-has-marks-below.slider,
@@ -4593,7 +4576,7 @@ GtkCheckButton.text-button, GtkRadioButton.text-button {
     border-color: transparent;
     background-image: -gtk-scaled(url("assets/scale-slider-1.svg"),url("assets/scale-slider-1@2.svg"));
     text-shadow:none;
-    icon-shadow:none;
+    -gtk-icon-shadow:none;
     border-style:none;
     border-width: 0;
     border-radius: 0;
@@ -4610,7 +4593,7 @@ GtkCheckButton.text-button, GtkRadioButton.text-button {
     border-color: transparent;
     background-image: -gtk-scaled(url("assets/scale-slider-2.svg"),url("assets/scale-slider-2@2.svg"));
     text-shadow:none;
-    icon-shadow:none;
+    -gtk-icon-shadow:none;
     border-style:none;
     border-width: 0;
     border-radius: 0;
@@ -4627,7 +4610,7 @@ GtkCheckButton.text-button, GtkRadioButton.text-button {
     border-color: transparent;
     background-image: -gtk-scaled(url("assets/scale-slider-3.svg"),url("assets/scale-slider-3@2.svg"));
     text-shadow:none;
-    icon-shadow:none;
+    -gtk-icon-shadow:none;
     border-style:none;
     border-width: 0;
     border-radius: 0;
@@ -4637,35 +4620,35 @@ GtkCheckButton.text-button, GtkRadioButton.text-button {
     background-image: -gtk-scaled(url("assets/scale-slider-3-osd.svg"),url("assets/scale-slider-3-osd@2.svg"));
     }
       
-    .scale.slider:insensitive,.osd .scale.slider:insensitive,
-    .scale.scale-has-marks-above.scale-has-marks-below.slider:insensitive,
-    .scale.vertical.scale-has-marks-above.scale-has-marks-below.slider:insensitive{
+    .scale.slider:disabled,.osd .scale.slider:disabled,
+    .scale.scale-has-marks-above.scale-has-marks-below.slider:disabled,
+    .scale.vertical.scale-has-marks-above.scale-has-marks-below.slider:disabled{
     color: rgba(0,0,0,0);
     border-color: transparent;
     background-image: -gtk-scaled(url("assets/scale-slider-ins.svg"),url("assets/scale-slider-ins@2.svg"));
     text-shadow:none;
-    icon-shadow:none;
+    -gtk-icon-shadow:none;
     border-style:none;
     border-width: 0;
     border-radius: 0;
     box-shadow: none;
     }
       
-    .scale.slider.vertical:insensitive,.osd .scale.slider.vertical:insensitive,
-    .scale.scale-has-marks-above.scale-has-marks-below.slider.vertical:insensitive,
-    .scale.vertical.scale-has-marks-above.scale-has-marks-below.slider.vertical:insensitive {
+    .scale.slider.vertical:disabled,.osd .scale.slider.vertical:disabled,
+    .scale.scale-has-marks-above.scale-has-marks-below.slider.vertical:disabled,
+    .scale.vertical.scale-has-marks-above.scale-has-marks-below.slider.vertical:disabled {
     color: rgba(0,0,0,0);
     border-color: transparent;
     background-image: -gtk-scaled(url("assets/scale-slider-ins-vert.svg"),url("assets/scale-slider-ins-vert@2.svg"));
     text-shadow:none;
-    icon-shadow:none;
+    -gtk-icon-shadow:none;
     border-style:none;
     border-width: 0;
     border-radius: 0;
     box-shadow: none;
     }
-    .osd .scale.slider:insensitive,
-    .osd .scale.slider.vertical:insensitive {
+    .osd .scale.slider:disabled,
+    .osd .scale.slider.vertical:disabled {
     background-image: none;
     }
     
@@ -4676,7 +4659,7 @@ GtkCheckButton.text-button, GtkRadioButton.text-button {
     border-color: transparent;
     background-image: -gtk-scaled(url("assets/scale-slider-backdrop.svg"),url("assets/scale-slider-backdrop@2.svg"));
     text-shadow:none;
-    icon-shadow:none;
+    -gtk-icon-shadow:none;
     border-style:none;
     border-width: 0;
     border-radius: 0;
@@ -4686,35 +4669,35 @@ GtkCheckButton.text-button, GtkRadioButton.text-button {
     background-image: -gtk-scaled(url("assets/scale-slider-1-osd-backdrop.svg"),url("assets/scale-slider-1-osd-backdrop@2.svg"));
     }
     
-    .scale.slider:backdrop:insensitive,.osd .scale.slider:backdrop:insensitive,
-    .scale.scale-has-marks-above.scale-has-marks-below.slider:backdrop:insensitive,
-    .scale.vertical.scale-has-marks-above.scale-has-marks-below.slider:backdrop:insensitive {
+    .scale.slider:backdrop:disabled,.osd .scale.slider:backdrop:disabled,
+    .scale.scale-has-marks-above.scale-has-marks-below.slider:backdrop:disabled,
+    .scale.vertical.scale-has-marks-above.scale-has-marks-below.slider:backdrop:disabled {
     color: rgba(0,0,0,0);
     border-color: transparent;
     background-image: -gtk-scaled(url("assets/scale-slider-ins.svg"),url("assets/scale-slider-ins@2.svg"));
     text-shadow:none;
-    icon-shadow:none;
+    -gtk-icon-shadow:none;
     border-style:none;
     border-width: 0;
     border-radius: 0;
     box-shadow: none;
     } 
     
-    .scale.slider.vertical:backdrop:insensitive,.osd .scale.slider.vertical:backdrop:insensitive,
-    .scale.scale-has-marks-above.scale-has-marks-below.slider.vertical:backdrop:insensitive,
-    .scale.vertical.scale-has-marks-above.scale-has-marks-below.slider.vertical:backdrop:insensitive {
+    .scale.slider.vertical:backdrop:disabled,.osd .scale.slider.vertical:backdrop:disabled,
+    .scale.scale-has-marks-above.scale-has-marks-below.slider.vertical:backdrop:disabled,
+    .scale.vertical.scale-has-marks-above.scale-has-marks-below.slider.vertical:backdrop:disabled {
     color: rgba(0,0,0,0);
     border-color: transparent;
     background-image: -gtk-scaled(url("assets/scale-slider-ins-vert.svg"),url("assets/scale-slider-ins-vert@2.svg"));
     text-shadow:none;
-    icon-shadow:none;
+    -gtk-icon-shadow:none;
     border-style:none;
     border-width: 0;
     border-radius: 0;
     box-shadow: none;
     }  
-    .osd .scale.slider:backdrop:insensitive,
-    .osd .scale.slider.vertical:backdrop:insensitive {
+    .osd .scale.slider:backdrop:disabled,
+    .osd .scale.slider.vertical:backdrop:disabled {
     background-image: none
     }
       
@@ -4759,24 +4742,24 @@ GtkCheckButton.text-button, GtkRadioButton.text-button {
     .scale.trough.highlight,
     .scale.scale-has-marks-above.scale-has-marks-below.trough.highlight,
     .scale.vertical.scale-has-marks-above.scale-has-marks-below.trough.highlight {
-      background-image: linear-gradient(to bottom, #8B8B8C);
+      background-image: image(#8B8B8C);
       border-color: #1c1c1e;
       box-shadow: 0 1px alpha(white,0.08); }
       .scale.trough.highlight.vertical,
       .scale.scale-has-marks-above.scale-has-marks-below.trough.highlight.vertical,
       .scale.vertical.scale-has-marks-above.scale-has-marks-below.trough.highlight.vertical {
-        background-image: linear-gradient(to bottom, #8B8B8C); }
+        background-image: image(#8B8B8C); }
       .scale.trough.highlight:backdrop,
       .scale.scale-has-marks-above.scale-has-marks-below.trough.highlight:backdrop,
       .scale.vertical.scale-has-marks-above.scale-has-marks-below.trough.highlight:backdrop {
         border-color: #202022;
         background-color: #8B8B8C;
         box-shadow: none; }
-    .scale.trough:insensitive, .scale.trough.vertical:insensitive,
-    .scale.scale-has-marks-above.scale-has-marks-below.trough:insensitive,
-    .scale.scale-has-marks-above.scale-has-marks-below.trough.vertical:insensitive,
-    .scale.vertical.scale-has-marks-above.scale-has-marks-below.trough:insensitive,
-    .scale.vertical.scale-has-marks-above.scale-has-marks-below.trough.vertical:insensitive {
+    .scale.trough:disabled, .scale.trough.vertical:disabled,
+    .scale.scale-has-marks-above.scale-has-marks-below.trough:disabled,
+    .scale.scale-has-marks-above.scale-has-marks-below.trough.vertical:disabled,
+    .scale.vertical.scale-has-marks-above.scale-has-marks-below.trough:disabled,
+    .scale.vertical.scale-has-marks-above.scale-has-marks-below.trough.vertical:disabled {
       border-color: #202022;
       background-image: none;
       background-color: transparent;
@@ -4788,11 +4771,11 @@ GtkCheckButton.text-button, GtkRadioButton.text-button {
       background-color: #28282a;
       background-image: none;
       box-shadow: none; }
-    .scale.trough:backdrop:insensitive, .scale.trough .highlight:backdrop:insensitive,
-    .scale.scale-has-marks-above.scale-has-marks-below.trough:backdrop:insensitive,
-    .scale.scale-has-marks-above.scale-has-marks-below.trough .highlight:backdrop:insensitive,
-    .scale.vertical.scale-has-marks-above.scale-has-marks-below.trough:backdrop:insensitive,
-    .scale.vertical.scale-has-marks-above.scale-has-marks-below.trough .highlight:backdrop:insensitive {
+    .scale.trough:backdrop:disabled, .scale.trough .highlight:backdrop:disabled,
+    .scale.scale-has-marks-above.scale-has-marks-below.trough:backdrop:disabled,
+    .scale.scale-has-marks-above.scale-has-marks-below.trough .highlight:backdrop:disabled,
+    .scale.vertical.scale-has-marks-above.scale-has-marks-below.trough:backdrop:disabled,
+    .scale.vertical.scale-has-marks-above.scale-has-marks-below.trough .highlight:backdrop:disabled {
       border-color: #222224;
       background-color: transparent; }
     .osd .scale.trough, .osd
@@ -4802,7 +4785,7 @@ GtkCheckButton.text-button, GtkRadioButton.text-button {
       box-shadow: none;
       margin: 9px;
       background-color: rgba(0, 0, 0, 0.2);
-      background-image: linear-gradient(to bottom, rgba(15,15,16,0.5));
+      background-image: image(rgba(15,15,16,0.5));
       outline-color: rgba(238, 238, 236, 0.2);
       outline-offset: -8px; }
       .osd .scale.trough.fine-tune, .osd
@@ -4814,11 +4797,11 @@ GtkCheckButton.text-button, GtkRadioButton.text-button {
       .scale.vertical.scale-has-marks-above.scale-has-marks-below.trough.highlight {
         background-image: none;
         background-color: #eeeeee; }
-      .osd .scale.trough:insensitive, .osd .scale.trough:backdrop:insensitive, .osd
-      .scale.scale-has-marks-above.scale-has-marks-below.trough:insensitive, .osd
-      .scale.scale-has-marks-above.scale-has-marks-below.trough:backdrop:insensitive, .osd
-      .scale.vertical.scale-has-marks-above.scale-has-marks-below.trough:insensitive, .osd
-      .scale.vertical.scale-has-marks-above.scale-has-marks-below.trough:backdrop:insensitive {
+      .osd .scale.trough:disabled, .osd .scale.trough:backdrop:disabled, .osd
+      .scale.scale-has-marks-above.scale-has-marks-below.trough:disabled, .osd
+      .scale.scale-has-marks-above.scale-has-marks-below.trough:backdrop:disabled, .osd
+      .scale.vertical.scale-has-marks-above.scale-has-marks-below.trough:disabled, .osd
+      .scale.vertical.scale-has-marks-above.scale-has-marks-below.trough:backdrop:disabled {
         border-color: transparent;
         background-color: transparent; }
       .osd .scale.trough:backdrop, .osd
@@ -4842,20 +4825,20 @@ GtkCheckButton.text-button, GtkRadioButton.text-button {
       .scale.scale-has-marks-above.scale-has-marks-below.trough.highlight:backdrop, .list-row:selected
       .scale.vertical.scale-has-marks-above.scale-has-marks-below.trough.highlight:backdrop {
         border-color: #060609; }
-    .list-row:selected .scale:insensitive, .list-row:selected .scale.trough.highlight:insensitive, .list-row:selected
-    .scale.scale-has-marks-above.scale-has-marks-below:insensitive, .list-row:selected
-    .scale.scale-has-marks-above.scale-has-marks-below.trough.highlight:insensitive, .list-row:selected
-    .scale.vertical.scale-has-marks-above.scale-has-marks-below:insensitive, .list-row:selected
-    .scale.vertical.scale-has-marks-above.scale-has-marks-below.trough.highlight:insensitive {
+    .list-row:selected .scale:disabled, .list-row:selected .scale.trough.highlight:disabled, .list-row:selected
+    .scale.scale-has-marks-above.scale-has-marks-below:disabled, .list-row:selected
+    .scale.scale-has-marks-above.scale-has-marks-below.trough.highlight:disabled, .list-row:selected
+    .scale.vertical.scale-has-marks-above.scale-has-marks-below:disabled, .list-row:selected
+    .scale.vertical.scale-has-marks-above.scale-has-marks-below.trough.highlight:disabled {
       border-color: #060609;
       box-shadow: none;
       background-color: @insensitive_fg_color;
       background-image: none; }
-      .list-row:selected .scale:insensitive:backdrop, .list-row:selected .scale.trough.highlight:insensitive:backdrop, .list-row:selected
-      .scale.scale-has-marks-above.scale-has-marks-below:insensitive:backdrop, .list-row:selected
-      .scale.scale-has-marks-above.scale-has-marks-below.trough.highlight:insensitive:backdrop, .list-row:selected
-      .scale.vertical.scale-has-marks-above.scale-has-marks-below:insensitive:backdrop, .list-row:selected
-      .scale.vertical.scale-has-marks-above.scale-has-marks-below.trough.highlight:insensitive:backdrop {
+      .list-row:selected .scale:disabled:backdrop, .list-row:selected .scale.trough.highlight:disabled:backdrop, .list-row:selected
+      .scale.scale-has-marks-above.scale-has-marks-below:disabled:backdrop, .list-row:selected
+      .scale.scale-has-marks-above.scale-has-marks-below.trough.highlight:disabled:backdrop, .list-row:selected
+      .scale.vertical.scale-has-marks-above.scale-has-marks-below:disabled:backdrop, .list-row:selected
+      .scale.vertical.scale-has-marks-above.scale-has-marks-below.trough.highlight:disabled:backdrop {
         background-color: @insensitive_fg_color; }
 
 .scale.scale-has-marks-below {
@@ -4887,7 +4870,7 @@ GtkCheckButton.text-button, GtkRadioButton.text-button {
     background-repeat: no-repeat;
     background-position: center;
     box-shadow: none; }
-  .scale.scale-has-marks-below.slider:insensitive {
+  .scale.scale-has-marks-below.slider:disabled {
     border-style: none;
     border-radius: 0;
     background-color: transparent;
@@ -4903,7 +4886,7 @@ GtkCheckButton.text-button, GtkRadioButton.text-button {
     background-repeat: no-repeat;
     background-position: center;
     box-shadow: none; }
-  .scale.scale-has-marks-below.slider:backdrop:insensitive {
+  .scale.scale-has-marks-below.slider:backdrop:disabled {
     border-style: none;
     border-radius: 0;
     background-color: transparent;
@@ -4941,7 +4924,7 @@ GtkCheckButton.text-button, GtkRadioButton.text-button {
     background-repeat: no-repeat;
     background-position: center;
     box-shadow: none; }
-  .scale.scale-has-marks-above.slider:insensitive {
+  .scale.scale-has-marks-above.slider:disabled {
     border-style: none;
     border-radius: 0;
     background-color: transparent;
@@ -4957,7 +4940,7 @@ GtkCheckButton.text-button, GtkRadioButton.text-button {
     background-repeat: no-repeat;
     background-position: center;
     box-shadow: none; }
-  .scale.scale-has-marks-above.slider:backdrop:insensitive {
+  .scale.scale-has-marks-above.slider:backdrop:disabled {
     border-style: none;
     border-radius: 0;
     background-color: transparent;
@@ -4995,7 +4978,7 @@ GtkCheckButton.text-button, GtkRadioButton.text-button {
     background-repeat: no-repeat;
     background-position: center;
     box-shadow: none; }
-  .scale.vertical.scale-has-marks-below.slider:insensitive {
+  .scale.vertical.scale-has-marks-below.slider:disabled {
     border-style: none;
     border-radius: 0;
     background-color: transparent;
@@ -5011,7 +4994,7 @@ GtkCheckButton.text-button, GtkRadioButton.text-button {
     background-repeat: no-repeat;
     background-position: center;
     box-shadow: none; }
-  .scale.vertical.scale-has-marks-below.slider:backdrop:insensitive {
+  .scale.vertical.scale-has-marks-below.slider:backdrop:disabled {
     border-style: none;
     border-radius: 0;
     background-color: transparent;
@@ -5049,7 +5032,7 @@ GtkCheckButton.text-button, GtkRadioButton.text-button {
     background-repeat: no-repeat;
     background-position: center;
     box-shadow: none; }
-  .scale.vertical.scale-has-marks-above.slider:insensitive {
+  .scale.vertical.scale-has-marks-above.slider:disabled {
     border-style: none;
     border-radius: 0;
     background-color: transparent;
@@ -5065,7 +5048,7 @@ GtkCheckButton.text-button, GtkRadioButton.text-button {
     background-repeat: no-repeat;
     background-position: center;
     box-shadow: none; }
-  .scale.vertical.scale-has-marks-above.slider:backdrop:insensitive {
+  .scale.vertical.scale-has-marks-above.slider:backdrop:disabled {
     border-style: none;
     border-radius: 0;
     background-color: transparent;
@@ -5236,8 +5219,6 @@ GtkScrolledWindow GtkViewport.frame {
 .separator {
   color: rgba(0, 0, 0, 0.3);
   }
-  GtkFileChooserButton .separator.vertical, GtkFontButton .separator.vertical {
-    -GtkWidget-wide-separators: true; }
 
 /*********
  * Lists *
@@ -5270,7 +5251,7 @@ GtkPlacesSidebar.sidebar .has-open-popup {
   box-shadow: inset 0 2px 2px -2px rgba(0, 0, 0, 0.2);
   background-image: none; }
 .list-row.activatable:backdrop:hover, GtkPlacesSidebar.sidebar .has-open-popup:backdrop {
-  background-color: transparent;
+  background-color: #2C2C2E;
   background-image: none; }
 .list-row.activatable:selected:active {
   box-shadow: inset 0 2px 3px -1px rgba(0, 0, 0, 0.5);
@@ -5305,7 +5286,7 @@ GtkPlacesSidebar.sidebar .has-open-popup {
                                       shade(@theme_bg_color, 0.9)
                                       );     
   text-shadow: 0 -1px rgba(0,0,0,0.7);
-  icon-shadow: 0 -1px rgba(0,0,0,0.7);                                   
+  -gtk-icon-shadow: 0 -1px rgba(0,0,0,0.7);                                   
   box-shadow: 0 1px alpha(white, 0.08) inset,
 				0 2px alpha(white, 0.04) inset,
 				1px 0 alpha(white, 0.03) inset,
@@ -5318,11 +5299,11 @@ GtkPlacesSidebar.sidebar .has-open-popup {
   .list-row:selected .titlebar .titlebutton.button,
   .titlebar .list-row:selected .titlebutton.button {
     border-color: transparent;
-    background-color: transparent;
+    background-color: #2C2C2E;
     background-image: none;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0);
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     color: #ccc; }
   .list-row:selected .button:hover {
     color: shade(@theme_fg_color, 1.12);
@@ -5351,7 +5332,7 @@ GtkPlacesSidebar.sidebar .has-open-popup {
 				0 -3px alpha(black, 0.01) inset,
 				0 1px 2px 0 rgba(0,0,0,0.2); 
     text-shadow: 0 1px rgba(0,0,0, 0.76923);
-    icon-shadow: 0 1px rgba(0,0,0, 0.76923); }
+    -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923); }
   .list-row:selected .button:active, .list-row:selected .button:checked {
     color: white;
     outline-color: rgba(46, 52, 54, 0.3);
@@ -5362,16 +5343,16 @@ GtkPlacesSidebar.sidebar .has-open-popup {
                                       mix(shade(@theme_bg_color, 1.2), @theme_selected_bg_color, 0.25));
     background-color: transparent;
     text-shadow: 0 1px rgba(0,0,0, 0.76923);
-    icon-shadow: 0 1px rgba(0,0,0, 0.76923);
+    -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923);
     box-shadow: inset 0 1px rgba(0, 0, 0, 0.07), inset 0 2px 1px -2px rgba(0, 0, 0, 0.6), 0 1px alpha(white,0.12); }
   .list-row:selected .button:backdrop, .list-row:selected .button.flat:backdrop, .list-row:selected .sidebar-button.button:backdrop, .list-row:selected .header-bar .titlebutton.button:backdrop, .header-bar .list-row:selected .titlebutton.button:backdrop,
   .list-row:selected .titlebar .titlebutton.button:backdrop,
   .titlebar .list-row:selected .titlebutton.button:backdrop {
     color: #8d9091;
     border-color: #a8a8a8;
-    background-image: linear-gradient(to bottom, #ededed);
+    background-image: image(#ededed);
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0);
     border-color: #184472; }
     .list-row:selected .button:backdrop:active, .list-row:selected .button:backdrop:checked, .list-row:selected .button.flat:backdrop:active, .list-row:selected .sidebar-button.button:backdrop:active, .list-row:selected .header-bar .titlebutton.button:backdrop:active, .header-bar .list-row:selected .titlebutton.button:backdrop:active,
@@ -5403,62 +5384,62 @@ GtkPlacesSidebar.sidebar .has-open-popup {
 				0 -2px alpha(black, 0.01) inset,
 				0 -3px alpha(black, 0.005) inset;
     text-shadow: none;
-    icon-shadow: none; }
-    .list-row:selected .button:backdrop:insensitive, .list-row:selected .button.flat:backdrop:insensitive, .list-row:selected .sidebar-button.button:backdrop:insensitive, .list-row:selected .header-bar .titlebutton.button:backdrop:insensitive, .header-bar .list-row:selected .titlebutton.button:backdrop:insensitive,
-    .list-row:selected .titlebar .titlebutton.button:backdrop:insensitive,
-    .titlebar .list-row:selected .titlebutton.button:backdrop:insensitive {
+    -gtk-icon-shadow: none; }
+    .list-row:selected .button:backdrop:disabled, .list-row:selected .button.flat:backdrop:disabled, .list-row:selected .sidebar-button.button:backdrop:disabled, .list-row:selected .header-bar .titlebutton.button:backdrop:disabled, .header-bar .list-row:selected .titlebutton.button:backdrop:disabled,
+    .list-row:selected .titlebar .titlebutton.button:backdrop:disabled,
+    .titlebar .list-row:selected .titlebutton.button:backdrop:disabled {
       color: #4a4a4d;
       border-color: #121214;
-      background-image: linear-gradient(to bottom, @theme_bg_color);
+      background-image: image(@theme_bg_color);
       text-shadow: none;
-      icon-shadow: none;
+      -gtk-icon-shadow: none;
       box-shadow: inset 0 1px rgba(255, 255, 255, 0); }
-      .list-row:selected .button:backdrop:insensitive > .label, .list-row:selected .button.flat:backdrop:insensitive > .label, .list-row:selected .sidebar-button.button:backdrop:insensitive > .label, .list-row:selected .header-bar .titlebutton.button:backdrop:insensitive > .label, .header-bar .list-row:selected .titlebutton.button:backdrop:insensitive > .label,
-      .list-row:selected .titlebar .titlebutton.button:backdrop:insensitive > .label,
-      .titlebar .list-row:selected .titlebutton.button:backdrop:insensitive > .label {
+      .list-row:selected .button:backdrop:disabled > .label, .list-row:selected .button.flat:backdrop:disabled > .label, .list-row:selected .sidebar-button.button:backdrop:disabled > .label, .list-row:selected .header-bar .titlebutton.button:backdrop:disabled > .label, .header-bar .list-row:selected .titlebutton.button:backdrop:disabled > .label,
+      .list-row:selected .titlebar .titlebutton.button:backdrop:disabled > .label,
+      .titlebar .list-row:selected .titlebutton.button:backdrop:disabled > .label {
         color: inherit; }
-      .list-row:selected .button:backdrop:insensitive:active, .list-row:selected .button:backdrop:insensitive:checked, .list-row:selected .button.flat:backdrop:insensitive:active, .list-row:selected .sidebar-button.button:backdrop:insensitive:active, .list-row:selected .header-bar .titlebutton.button:backdrop:insensitive:active, .header-bar .list-row:selected .titlebutton.button:backdrop:insensitive:active,
-      .list-row:selected .titlebar .titlebutton.button:backdrop:insensitive:active,
-      .titlebar .list-row:selected .titlebutton.button:backdrop:insensitive:active, .list-row:selected .button.flat:backdrop:insensitive:checked, .list-row:selected .sidebar-button.button:backdrop:insensitive:checked, .list-row:selected .header-bar .titlebutton.button:backdrop:insensitive:checked, .header-bar .list-row:selected .titlebutton.button:backdrop:insensitive:checked,
-      .list-row:selected .titlebar .titlebutton.button:backdrop:insensitive:checked,
-      .titlebar .list-row:selected .titlebutton.button:backdrop:insensitive:checked {
+      .list-row:selected .button:backdrop:disabled:active, .list-row:selected .button:backdrop:disabled:checked, .list-row:selected .button.flat:backdrop:disabled:active, .list-row:selected .sidebar-button.button:backdrop:disabled:active, .list-row:selected .header-bar .titlebutton.button:backdrop:disabled:active, .header-bar .list-row:selected .titlebutton.button:backdrop:disabled:active,
+      .list-row:selected .titlebar .titlebutton.button:backdrop:disabled:active,
+      .titlebar .list-row:selected .titlebutton.button:backdrop:disabled:active, .list-row:selected .button.flat:backdrop:disabled:checked, .list-row:selected .sidebar-button.button:backdrop:disabled:checked, .list-row:selected .header-bar .titlebutton.button:backdrop:disabled:checked, .header-bar .list-row:selected .titlebutton.button:backdrop:disabled:checked,
+      .list-row:selected .titlebar .titlebutton.button:backdrop:disabled:checked,
+      .titlebar .list-row:selected .titlebutton.button:backdrop:disabled:checked {
         color: #7a7a7d;
         border-color: #101012;
         background-image: linear-gradient(to bottom, 
                                       shade( mix(shade(@theme_bg_color, 0.9), @theme_selected_bg_color, 0.20), 0.8), 
                                       shade( mix(shade(@theme_bg_color, 1.2), @theme_selected_bg_color, 0.20), 0.8));
         box-shadow: inset 0 1px rgba(255, 255, 255, 0);}
-        .list-row:selected .button:backdrop:insensitive:active > .label, .list-row:selected .button:backdrop:insensitive:checked > .label, .list-row:selected .button.flat:backdrop:insensitive:active > .label, .list-row:selected .sidebar-button.button:backdrop:insensitive:active > .label, .list-row:selected .header-bar .titlebutton.button:backdrop:insensitive:active > .label, .header-bar .list-row:selected .titlebutton.button:backdrop:insensitive:active > .label,
-        .list-row:selected .titlebar .titlebutton.button:backdrop:insensitive:active > .label,
-        .titlebar .list-row:selected .titlebutton.button:backdrop:insensitive:active > .label, .list-row:selected .button.flat:backdrop:insensitive:checked > .label, .list-row:selected .sidebar-button.button:backdrop:insensitive:checked > .label, .list-row:selected .header-bar .titlebutton.button:backdrop:insensitive:checked > .label, .header-bar .list-row:selected .titlebutton.button:backdrop:insensitive:checked > .label,
-        .list-row:selected .titlebar .titlebutton.button:backdrop:insensitive:checked > .label,
-        .titlebar .list-row:selected .titlebutton.button:backdrop:insensitive:checked > .label {
+        .list-row:selected .button:backdrop:disabled:active > .label, .list-row:selected .button:backdrop:disabled:checked > .label, .list-row:selected .button.flat:backdrop:disabled:active > .label, .list-row:selected .sidebar-button.button:backdrop:disabled:active > .label, .list-row:selected .header-bar .titlebutton.button:backdrop:disabled:active > .label, .header-bar .list-row:selected .titlebutton.button:backdrop:disabled:active > .label,
+        .list-row:selected .titlebar .titlebutton.button:backdrop:disabled:active > .label,
+        .titlebar .list-row:selected .titlebutton.button:backdrop:disabled:active > .label, .list-row:selected .button.flat:backdrop:disabled:checked > .label, .list-row:selected .sidebar-button.button:backdrop:disabled:checked > .label, .list-row:selected .header-bar .titlebutton.button:backdrop:disabled:checked > .label, .header-bar .list-row:selected .titlebutton.button:backdrop:disabled:checked > .label,
+        .list-row:selected .titlebar .titlebutton.button:backdrop:disabled:checked > .label,
+        .titlebar .list-row:selected .titlebutton.button:backdrop:disabled:checked > .label {
           color: inherit; }
   .list-row:selected .button.flat:backdrop, .list-row:selected .sidebar-button.button:backdrop, .list-row:selected .header-bar .titlebutton.button:backdrop, .header-bar .list-row:selected .titlebutton.button:backdrop,
   .list-row:selected .titlebar .titlebutton.button:backdrop,
   .titlebar .list-row:selected .titlebutton.button:backdrop {
     border-color: transparent;
-    background-color: transparent;
+    background-color: #2C2C2E;
     background-image: none;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0);
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     color: #ccc; }
-  .list-row:selected .button:insensitive {
+  .list-row:selected .button:disabled {
     color: @insensitive_fg_color;
     border-color: #121214;
-    background-image: linear-gradient(to bottom, @theme_bg_color);
+    background-image: image(@theme_bg_color);
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0); }
-    .list-row:selected .button:insensitive > .label {
+    .list-row:selected .button:disabled > .label {
       color: inherit; }
-    .list-row:selected .button:insensitive:active, .list-row:selected .button:insensitive:checked {
+    .list-row:selected .button:disabled:active, .list-row:selected .button:disabled:checked {
       color: @insensitive_fg_color;
       border-color: #121214;
       background-image: linear-gradient(to bottom, shade(@theme_bg_color,1.2), @theme_bg_color);
       box-shadow: inset 0 1px rgba(255, 255, 255, 0); }
-      .list-row:selected .button:insensitive:active > .label, .list-row:selected .button:insensitive:checked > .label {
+      .list-row:selected .button:disabled:active > .label, .list-row:selected .button:disabled:checked > .label {
         color: inherit; }
 
 .list-row {
@@ -5491,11 +5472,11 @@ GtkPlacesSidebar.sidebar .has-open-popup {
     color: #eeeeec;
     border-color: rgba(0, 0, 0, 0.6);
     background-color: transparent;
-    background-image: linear-gradient(to bottom, rgba(15,15,19, 0.5));
+    background-image: image(rgba(15,15,19, 0.5));
     background-clip: padding-box;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0.04);
     text-shadow: 0 1px black;
-    icon-shadow: 0 1px black;
+    -gtk-icon-shadow: 0 1px black;
     outline-color: rgba(238, 238, 236, 0.3); }
     .app-notification .button.flat, .app-notification .sidebar-button.button, .app-notification .header-bar .titlebutton.button, .header-bar .app-notification .titlebutton.button,
     .app-notification .titlebar .titlebutton.button,
@@ -5506,17 +5487,17 @@ GtkPlacesSidebar.sidebar .has-open-popup {
     .header-bar .app-notification.frame .titlebutton.button,
     .app-notification.frame .titlebar .titlebutton.button,
     .titlebar .app-notification.frame .titlebutton.button {
-      icon-shadow: 0 1px black;
+      -gtk-icon-shadow: 0 1px black;
       text-shadow: 0 1px black; }
     .app-notification .button:hover,
     .app-notification.frame .button:hover {
       color: white;
       border-color: rgba(0, 0, 0, 0.7);
-      background-image: linear-gradient(to bottom, rgba(42,42,48, 0.7));
+      background-image: image(rgba(42,42,48, 0.7));
       background-clip: padding-box;
       box-shadow: inset 0 1px rgba(255, 255, 255, 0.07);
       text-shadow: 0 1px black;
-      icon-shadow: 0 1px black;
+      -gtk-icon-shadow: 0 1px black;
       outline-color: rgba(238, 238, 236, 0.3); }
     .app-notification .button:active, .app-notification .button:checked, .app-notification .button:backdrop:active, .app-notification .button:backdrop:checked,
     .app-notification.frame .button:active,
@@ -5525,31 +5506,31 @@ GtkPlacesSidebar.sidebar .has-open-popup {
     .app-notification.frame .button:backdrop:checked {
       color: white;
       border-color: rgba(0, 0, 0, 0.9);
-      background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.7));
+      background-image: image(rgba(0, 0, 0, 0.7));
       background-clip: padding-box;
       box-shadow: 0 1px alpha(white, 0.08);
       text-shadow: none;
-      icon-shadow: none;
+      -gtk-icon-shadow: none;
       outline-color: rgba(238, 238, 236, 0.3); }
-    .app-notification .button:insensitive, .app-notification .button:backdrop:insensitive,
-    .app-notification.frame .button:insensitive,
-    .app-notification.frame .button:backdrop:insensitive {
+    .app-notification .button:disabled, .app-notification .button:backdrop:disabled,
+    .app-notification.frame .button:disabled,
+    .app-notification.frame .button:backdrop:disabled {
       color: @insensitive_fg_color;
       border-color: rgba(0, 0, 0, 0.4);
-      background-image: linear-gradient(to bottom, rgba(15,15,19, 0.15));
+      background-image: image(rgba(15,15,19, 0.15));
       background-clip: padding-box;
       box-shadow: none;
       text-shadow: none;
-      icon-shadow: none; }
+      -gtk-icon-shadow: none; }
     .app-notification .button:backdrop,
     .app-notification.frame .button:backdrop {
       color: @theme_unfocused_fg_color;
       border-color: rgba(0, 0, 0, 0.5);
-      background-image: linear-gradient(to bottom, rgba(15,15,19, 0.4));
+      background-image: image(rgba(15,15,19, 0.4));
       background-clip: padding-box;
       box-shadow: none;
       text-shadow: none;
-      icon-shadow: none; }
+      -gtk-icon-shadow: none; }
 
 /*************
  * Expanders *
@@ -5583,10 +5564,10 @@ GtkCalendar {
     GtkCalendar.button:backdrop, .header-bar GtkCalendar.button.titlebutton:backdrop,
     .titlebar GtkCalendar.button.titlebutton:backdrop {
       color: #999; }
-    GtkCalendar.button:insensitive, .header-bar GtkCalendar.button.titlebutton:insensitive,
-    .titlebar GtkCalendar.button.titlebutton:insensitive {
+    GtkCalendar.button:disabled, .header-bar GtkCalendar.button.titlebutton:disabled,
+    .titlebar GtkCalendar.button.titlebutton:disabled {
       color: @insensitive_fg_color; }
-  GtkCalendar:inconsistent, GtkCalendar:inconsistent:backdrop {
+  GtkCalendar:indeterminate, GtkCalendar:indeterminate:backdrop {
     color: alpha(currentColor,0.55); }
   GtkCalendar.highlight, GtkCalendar.highlight:backdrop {
     font-size: smaller;
@@ -5629,7 +5610,7 @@ GtkCalendar {
                                       shade(#3c3c3e, 0.9)
                                       );
   text-shadow: 0 -1px rgba(0,0,0,0.7);
-  icon-shadow: 0 -1px rgba(0,0,0,0.7);
+  -gtk-icon-shadow: 0 -1px rgba(0,0,0,0.7);
   box-shadow: 0 1px alpha(white, 0.08) inset,
 				0 2px alpha(white, 0.04) inset,
 				1px 0 alpha(white, 0.03) inset,
@@ -5651,7 +5632,7 @@ GtkCalendar {
                                       shade(#3c3c3e, 0.9)
                                       );
     text-shadow: 0 1px rgba(0,0,0, 0.76923);
-    icon-shadow: 0 1px rgba(0,0,0, 0.76923);
+    -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923);
     box-shadow: 0 1px alpha(white, 0.09) inset,
 				0 2px alpha(white, 0.015) inset,
 				1px 0 alpha(white, 0.045) inset,
@@ -5668,16 +5649,16 @@ GtkCalendar {
                                       mix(shade(#3c3c3e, 0.9), @theme_selected_bg_color, 0.30), 
                                       mix(shade(#3c3c3e, 1.2), @theme_selected_bg_color, 0.25));
     text-shadow: 0 1px rgba(0,0,0, 0.76923);
-    icon-shadow: 0 1px rgba(0,0,0, 0.76923);
+    -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923);
     box-shadow: inset 0 1px rgba(0, 0, 0, 0.07), inset 0 2px 1px -2px rgba(0, 0, 0, 0.6), 0 1px alpha(white,0.12); }
-  .message-dialog.csd .dialog-action-area .button:insensitive {
+  .message-dialog.csd .dialog-action-area .button:disabled {
     color: @insensitive_fg_color;
     border-color: #1c1c1f;
-    background-image: linear-gradient(to bottom, #2c2c2e);
+    background-image: image(#2c2c2e);
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0); }
-    .message-dialog.csd .dialog-action-area .button:insensitive > .label {
+    .message-dialog.csd .dialog-action-area .button:disabled > .label {
       color: inherit; }
   .message-dialog.csd .dialog-action-area .button:backdrop {
     color: @theme_unfocused_fg_color;
@@ -5691,7 +5672,7 @@ GtkCalendar {
                                       shade(shade(#3c3c3e, 0.9), 0.8)
                                       );
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     box-shadow: 0 1px alpha(white, 0.02) inset,
 				0 2px alpha(white, 0.01) inset,
 				1px 0 alpha(white, 0.015) inset,
@@ -5699,14 +5680,14 @@ GtkCalendar {
 				0 -1px alpha(white, 0.015) inset,
 				0 -2px alpha(black, 0.01) inset,
 				0 -3px alpha(black, 0.005) inset; }
-  .message-dialog.csd .dialog-action-area .button:backdrop:insensitive {
+  .message-dialog.csd .dialog-action-area .button:backdrop:disabled {
     color: #4a4a4d;
     border-color: #202022;
-    background-image: linear-gradient(to bottom, #2a2a2c);
+    background-image: image(#2a2a2c);
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0); }
-    .message-dialog.csd .dialog-action-area .button:backdrop:insensitive > .label {
+    .message-dialog.csd .dialog-action-area .button:backdrop:disabled > .label {
       color: inherit; }
   .message-dialog.csd .dialog-action-area .button.suggested-action {
     color: white;
@@ -5721,7 +5702,7 @@ GtkCalendar {
                                       shade(@theme_selected_bg_color, 0.9)
                                       );
     text-shadow: 0 -1px rgba(0, 0, 0, 0.54353);
-    icon-shadow: 0 -1px rgba(0, 0, 0, 0.54353);
+    -gtk-icon-shadow: 0 -1px rgba(0, 0, 0, 0.54353);
     box-shadow: 0 1px alpha(white, 0.04) inset,
 				0 2px alpha(white, 0.015) inset,
 				1px 0 alpha(white, 0.03) inset,
@@ -5743,7 +5724,7 @@ GtkCalendar {
                                       shade(shade(@theme_selected_bg_color, 0.9), 0.98)
                                       );
       text-shadow: 0 -1px rgba(0, 0, 0, 0.51153);
-      icon-shadow: 0 -1px rgba(0, 0, 0, 0.51153);
+      -gtk-icon-shadow: 0 -1px rgba(0, 0, 0, 0.51153);
       box-shadow: 0 1px alpha(white, 0.09) inset,
 				0 2px alpha(white, 0.015) inset,
 				1px 0 alpha(white, 0.045) inset,
@@ -5760,7 +5741,7 @@ GtkCalendar {
                                       mix(shade(@theme_selected_bg_color, 0.9), @theme_selected_bg_color, 0.30), 
                                       mix(shade(@theme_selected_bg_color, 1.2), @theme_selected_bg_color, 0.25));
       text-shadow: 0 -1px rgba(0, 0, 0, 0.62353);
-      icon-shadow: 0 -1px rgba(0, 0, 0, 0.62353);
+      -gtk-icon-shadow: 0 -1px rgba(0, 0, 0, 0.62353);
       box-shadow: inset 0 1px rgba(0, 0, 0, 0.07), inset 0 2px 1px -2px rgba(0, 0, 0, 0.6), 0 1px alpha(white,0.12); }
     .message-dialog.csd .dialog-action-area .button.suggested-action:backdrop {
       color: @theme_unfocused_fg_color;
@@ -5774,7 +5755,7 @@ GtkCalendar {
                                       shade(shade(@theme_selected_bg_color, 0.9), 0.8)
                                       );
       text-shadow: none;
-      icon-shadow: none;
+      -gtk-icon-shadow: none;
       box-shadow: 0 1px alpha(white, 0.02) inset,
 				0 2px alpha(white, 0.01) inset,
 				1px 0 alpha(white, 0.015) inset,
@@ -5782,23 +5763,23 @@ GtkCalendar {
 				0 -1px alpha(white, 0.015) inset,
 				0 -2px alpha(black, 0.01) inset,
 				0 -3px alpha(black, 0.005) inset; }
-      .message-dialog.csd .dialog-action-area .button.suggested-action:backdrop:insensitive {
+      .message-dialog.csd .dialog-action-area .button.suggested-action:backdrop:disabled {
         color: #4a4a4d;
         border-color: #202022;
-        background-image: linear-gradient(to bottom, #262628);
+        background-image: image(#262628);
         text-shadow: none;
-        icon-shadow: none;
+        -gtk-icon-shadow: none;
         box-shadow: inset 0 1px rgba(255, 255, 255, 0); }
-        .message-dialog.csd .dialog-action-area .button.suggested-action:backdrop:insensitive > .label {
+        .message-dialog.csd .dialog-action-area .button.suggested-action:backdrop:disabled > .label {
           color: inherit; }
-    .message-dialog.csd .dialog-action-area .button.suggested-action:insensitive {
+    .message-dialog.csd .dialog-action-area .button.suggested-action:disabled {
       color: @insensitive_fg_color;
       border-color: #1c1c1f;
-      background-image: linear-gradient(to bottom, #2c2c2e);
+      background-image: image(#2c2c2e);
       text-shadow: none;
-      icon-shadow: none;
+      -gtk-icon-shadow: none;
       box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px alpha(white,0.08); }
-      .message-dialog.csd .dialog-action-area .button.suggested-action:insensitive > .label {
+      .message-dialog.csd .dialog-action-area .button.suggested-action:disabled > .label {
         color: inherit; }
   .message-dialog.csd .dialog-action-area .button.destructive-action {
     color: white;
@@ -5813,7 +5794,7 @@ GtkCalendar {
                                       shade(#940000, 0.9)
                                       ); 
     text-shadow: 0 -1px rgba(0, 0, 0, 0.56078);
-    icon-shadow: 0 -1px rgba(0, 0, 0, 0.56078);
+    -gtk-icon-shadow: 0 -1px rgba(0, 0, 0, 0.56078);
     box-shadow: 0 1px alpha(white, 0.04) inset,
 				0 2px alpha(white, 0.015) inset,
 				1px 0 alpha(white, 0.03) inset,
@@ -5835,7 +5816,7 @@ GtkCalendar {
                                       shade(shade(#940000, 0.9), 0.98)
                                       ); 
       text-shadow: 0 -1px rgba(0, 0, 0, 0.52878);
-      icon-shadow: 0 -1px rgba(0, 0, 0, 0.52878);
+      -gtk-icon-shadow: 0 -1px rgba(0, 0, 0, 0.52878);
       box-shadow: 0 1px alpha(white, 0.09) inset,
 				0 2px alpha(white, 0.015) inset,
 				1px 0 alpha(white, 0.045) inset,
@@ -5852,7 +5833,7 @@ GtkCalendar {
                                       mix(shade(#940000, 0.9), @theme_selected_bg_color, 0.30), 
                                       mix(shade(#940000, 1.2), @theme_selected_bg_color, 0.25));
       text-shadow: 0 -1px rgba(0, 0, 0, 0.64078);
-      icon-shadow: 0 -1px rgba(0, 0, 0, 0.64078);
+      -gtk-icon-shadow: 0 -1px rgba(0, 0, 0, 0.64078);
       box-shadow: inset 0 1px rgba(0, 0, 0, 0.07), inset 0 2px 1px -2px rgba(0, 0, 0, 0.6), 0 1px alpha(white,0.12); }
     .message-dialog.csd .dialog-action-area .button.destructive-action:backdrop {
       color: #fbd4d4;
@@ -5866,7 +5847,7 @@ GtkCalendar {
                                       shade(shade(#940000, 0.9), 0.8)
                                       ); 
       text-shadow: none;
-      icon-shadow: none;
+      -gtk-icon-shadow: none;
       box-shadow: 0 1px alpha(white, 0.02) inset,
 				0 2px alpha(white, 0.01) inset,
 				1px 0 alpha(white, 0.015) inset,
@@ -5874,45 +5855,45 @@ GtkCalendar {
 				0 -1px alpha(white, 0.015) inset,
 				0 -2px alpha(black, 0.01) inset,
 				0 -3px alpha(black, 0.005) inset;  }
-      .message-dialog.csd .dialog-action-area .button.destructive-action:backdrop:insensitive {
+      .message-dialog.csd .dialog-action-area .button.destructive-action:backdrop:disabled {
         color: #4a4a4d;
         border-color: #202022;
-        background-image: linear-gradient(to bottom, #262628);
+        background-image: image(#262628);
         text-shadow: none;
-        icon-shadow: none;
+        -gtk-icon-shadow: none;
         box-shadow: inset 0 1px rgba(255, 255, 255, 0); }
-        .message-dialog.csd .dialog-action-area .button.destructive-action:backdrop:insensitive > .label {
+        .message-dialog.csd .dialog-action-area .button.destructive-action:backdrop:disabled > .label {
           color: inherit; }
-    .message-dialog.csd .dialog-action-area .button.destructive-action:insensitive {
+    .message-dialog.csd .dialog-action-area .button.destructive-action:disabled {
       color: @insensitive_fg_color;
       border-color: #1c1c1f;
-      background-image: linear-gradient(to bottom, #2c2c2e);
+      background-image: image(#2c2c2e);
       text-shadow: none;
-      icon-shadow: none;
+      -gtk-icon-shadow: none;
       box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px alpha(white,0.08); }
-      .message-dialog.csd .dialog-action-area .button.destructive-action:insensitive > .label {
+      .message-dialog.csd .dialog-action-area .button.destructive-action:disabled > .label {
         color: inherit; }
-.message-dialog.csd .dialog-action-area .button, .message-dialog.csd .dialog-action-area .button:hover, .message-dialog.csd .dialog-action-area .button:active, .message-dialog.csd .dialog-action-area .button:insensitive, .message-dialog.csd .dialog-action-area .button:backdrop, .message-dialog.csd .dialog-action-area .button:backdrop:insensitive, .message-dialog.csd .dialog-action-area .button.suggested-action, .message-dialog.csd .dialog-action-area .button.suggested-action:hover, .message-dialog.csd .dialog-action-area .button.suggested-action:active, .message-dialog.csd .dialog-action-area .button.suggested-action:backdrop, .message-dialog.csd .dialog-action-area .button.suggested-action:backdrop:insensitive, .message-dialog.csd .dialog-action-area .button.suggested-action:insensitive, .message-dialog.csd .dialog-action-area .button.destructive-action, .message-dialog.csd .dialog-action-area .button.destructive-action:hover, .message-dialog.csd .dialog-action-area .button.destructive-action:active, .message-dialog.csd .dialog-action-area .button.destructive-action:backdrop, .message-dialog.csd .dialog-action-area .button.destructive-action:backdrop:insensitive, .message-dialog.csd .dialog-action-area .button.destructive-action:insensitive {
+.message-dialog.csd .dialog-action-area .button, .message-dialog.csd .dialog-action-area .button:hover, .message-dialog.csd .dialog-action-area .button:active, .message-dialog.csd .dialog-action-area .button:disabled, .message-dialog.csd .dialog-action-area .button:backdrop, .message-dialog.csd .dialog-action-area .button:backdrop:disabled, .message-dialog.csd .dialog-action-area .button.suggested-action, .message-dialog.csd .dialog-action-area .button.suggested-action:hover, .message-dialog.csd .dialog-action-area .button.suggested-action:active, .message-dialog.csd .dialog-action-area .button.suggested-action:backdrop, .message-dialog.csd .dialog-action-area .button.suggested-action:backdrop:disabled, .message-dialog.csd .dialog-action-area .button.suggested-action:disabled, .message-dialog.csd .dialog-action-area .button.destructive-action, .message-dialog.csd .dialog-action-area .button.destructive-action:hover, .message-dialog.csd .dialog-action-area .button.destructive-action:active, .message-dialog.csd .dialog-action-area .button.destructive-action:backdrop, .message-dialog.csd .dialog-action-area .button.destructive-action:backdrop:disabled, .message-dialog.csd .dialog-action-area .button.destructive-action:disabled {
   border-left-style: solid;
   border-right-style: none;
   border-bottom-style: none; }
 .message-dialog.csd .dialog-action-area .button:last-child {
   border-bottom-right-radius: 7px;
-  outline-bottom-right-radius: 5px; }
+  -gtk-outline-bottom-right-radius: 5px; }
 .message-dialog.csd .dialog-action-area .button:first-child {
   border-left-style: none;
   border-bottom-left-radius: 7px;
-  outline-bottom-left-radius: 5px; }
+  -gtk-outline-bottom-left-radius: 5px; }
 
 GtkFileChooserDialog .search-bar {
 border-bottom-color: #1c1c1e;
-  background-color: transparent;
-  background-image: linear-gradient(to bottom, rgba(255,255,255,0.06), rgba(255,255,255,0.22) ), url("assets/background-dark-transparent.png");
+  background-color: #2C2C2E;
+  background-image: linear-gradient(to bottom, rgba(255,255,255,0.06), rgba(255,255,255,0.22) ), url("assets/background-dark.png");
   box-shadow: 0 1px #49494b, inset 0 -1px 2px #49494b, inset 0 1px 2px alpha(white,0.35), inset 0 -1px #1c1c1e;
   box-shadow: none; }
   GtkFileChooserDialog .search-bar:backdrop {
-    background-color: transparent;
-    background-image: linear-gradient(to bottom, rgba(255,255,255,0.15), rgba(255,255,255,0.04)), url("assets/background-dark-transparent-backdrop.png");
+    background-color: #2C2C2E;
+    background-image: linear-gradient(to bottom, rgba(255,255,255,0.15), rgba(255,255,255,0.04)), url("assets/background-dark-backdrop.png");
     box-shadow: 0 1px #4c4c4e,inset 0 -1px 0px #4c4c4e, inset 0 1px 2px alpha(white,0.15), inset 0 -1px #202022; 
     border-color: #202022;}
 GtkFileChooserDialog .dialog-action-box {
@@ -5953,7 +5934,7 @@ GtkPlacesSidebar.sidebar .sidebar-new-bookmark-row {
 .sidebar-button.button, .header-bar .sidebar-button.button.titlebutton,
 .titlebar .sidebar-button.button.titlebutton {
   border-radius: 100%;
-  outline-radius: 100%; }
+  -gtk-outline-radius: 100%; }
   .sidebar-button.button.image-button, GtkScaleButton.sidebar-button.button,
   GtkVolumeButton.sidebar-button.button, .header-bar .sidebar-button.titlebutton.button,
   .titlebar .sidebar-button.titlebutton.button {
@@ -5988,7 +5969,7 @@ GtkPaned.wide {
   -GtkPaned-handle-size: 5;
   margin: 0; }
   GtkPaned.wide .pane-separator {
-    background-color: transparent;
+    background-color: #2C2C2E;
     border-style: none solid;
     border-color: #030306;
     border-width: 1px; }
@@ -6053,7 +6034,7 @@ GtkInfoBar {
                                       shade(shade(@theme_base_color, 1.8), 0.9)
                                       );     
   text-shadow: 0 -1px rgba(0,0,0,0.7);
-  icon-shadow: 0 -1px rgba(0,0,0,0.7);                                   
+  -gtk-icon-shadow: 0 -1px rgba(0,0,0,0.7);                                   
   box-shadow: 0 1px alpha(white, 0.08) inset,
 				0 2px alpha(white, 0.04) inset,
 				1px 0 alpha(white, 0.03) inset,
@@ -6088,7 +6069,7 @@ GtkInfoBar {
                                       shade(#a75400, 0.9)
                                       );     
   text-shadow: 0 -1px rgba(0,0,0,0.7);
-  icon-shadow: 0 -1px rgba(0,0,0,0.7);                                   
+  -gtk-icon-shadow: 0 -1px rgba(0,0,0,0.7);                                   
   box-shadow: 0 1px alpha(white, 0.08) inset,
 				0 2px alpha(white, 0.04) inset,
 				1px 0 alpha(white, 0.03) inset,
@@ -6123,7 +6104,7 @@ GtkInfoBar {
                                       shade(#a70000, 0.9)
                                       );     
   text-shadow: 0 -1px rgba(0,0,0,0.7);
-  icon-shadow: 0 -1px rgba(0,0,0,0.7);                                   
+  -gtk-icon-shadow: 0 -1px rgba(0,0,0,0.7);                                   
   box-shadow: 0 1px alpha(white, 0.08) inset,
 				0 2px alpha(white, 0.04) inset,
 				1px 0 alpha(white, 0.03) inset,
@@ -6163,7 +6144,7 @@ GtkInfoBar {
 				0 -3px alpha(black, 0.01) inset,
 				0 1px 2px 0 rgba(0,0,0,0.2); 
     text-shadow: 0 1px rgba(0,0,0, 0.76923);
-    icon-shadow: 0 1px rgba(0,0,0, 0.76923); }
+    -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923); }
       
 .warning .button:hover,
 .warning GtkComboBox:hover {
@@ -6193,7 +6174,7 @@ GtkInfoBar {
 				0 -3px alpha(black, 0.01) inset,
 				0 1px 2px 0 rgba(0,0,0,0.2); 
     text-shadow: 0 1px rgba(0,0,0, 0.76923);
-    icon-shadow: 0 1px rgba(0,0,0, 0.76923); }
+    -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923); }
       
     .error .button:hover,
     .error GtkComboBox:hover {
@@ -6223,7 +6204,7 @@ GtkInfoBar {
 				0 -3px alpha(black, 0.01) inset,
 				0 1px 2px 0 rgba(0,0,0,0.2); 
     text-shadow: 0 1px rgba(0,0,0, 0.76923);
-    icon-shadow: 0 1px rgba(0,0,0, 0.76923); }
+    -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923); }
       
     .info .button:active,
     .question .button:active {
@@ -6236,7 +6217,7 @@ GtkInfoBar {
                                       mix(shade(shade(@theme_base_color, 1.8), 1.2), @theme_selected_bg_color, 0.25));
     background-color: transparent;
     text-shadow: 0 1px rgba(0,0,0, 0.76923);
-    icon-shadow: 0 1px rgba(0,0,0, 0.76923);
+    -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923);
     box-shadow: inset 0 1px rgba(0, 0, 0, 0.07), inset 0 2px 1px -2px rgba(0, 0, 0, 0.6), 0 1px alpha(white,0.12); }
       
 .warning .button:active {
@@ -6250,7 +6231,7 @@ GtkInfoBar {
                                       mix(shade(#a75400, 1.2), @theme_selected_bg_color, 0.25));
     background-color: transparent;
     text-shadow: 0 1px rgba(0,0,0, 0.76923);
-    icon-shadow: 0 1px rgba(0,0,0, 0.76923);
+    -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923);
     box-shadow: inset 0 1px rgba(0, 0, 0, 0.07), inset 0 2px 1px -2px rgba(0, 0, 0, 0.6), 0 1px alpha(white,0.12); }
       
     .error .button:active {
@@ -6264,39 +6245,39 @@ GtkInfoBar {
                                       mix(shade(#a70000, 1.2), @theme_selected_bg_color, 0.25));
     background-color: transparent;
     text-shadow: 0 1px rgba(0,0,0, 0.76923);
-    icon-shadow: 0 1px rgba(0,0,0, 0.76923);
+    -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923);
     box-shadow: inset 0 1px rgba(0, 0, 0, 0.07), inset 0 2px 1px -2px rgba(0, 0, 0, 0.6), 0 1px alpha(white,0.12); }
       
-    .info .button:insensitive,
-    .question .button:insensitive,
-    .warning .button:insensitive,
-    .error .button:insensitive
-    .info GtkComboBox:insensitive,
-    .question GtkComboBox:insensitive,
-    .warning GtkComboBox:insensitive,
-    .error GtkComboBox:insensitive {
+    .info .button:disabled,
+    .question .button:disabled,
+    .warning .button:disabled,
+    .error .button:disabled
+    .info GtkComboBox:disabled,
+    .question GtkComboBox:disabled,
+    .warning GtkComboBox:disabled,
+    .error GtkComboBox:disabled {
       color:alpha(white, 0.6);
       border-style: solid;
       border-color: #363639;
-      background-image: linear-gradient(to bottom, rgba(0,0,0,0.05));
+      background-image: image(rgba(0,0,0,0.05));
       text-shadow: none;
-      icon-shadow: none;
+      -gtk-icon-shadow: none;
       box-shadow:  none; }
-      .info .button:insensitive > .label, .info .header-bar .button.titlebutton:insensitive > .label,
-      .info .titlebar .button.titlebutton:insensitive > .label,
-      .info GtkComboBox:insensitive > .label,
-      .question .button:insensitive > .label,
-      .question GtkComboBox:insensitive > .label,
-      .question .header-bar .button.titlebutton:insensitive > .label,
-      .question .titlebar .button.titlebutton:insensitive > .label,
-      .warning .button:insensitive > .label,
-      .warning GtkComboBox:insensitive > .label,
-      .warning .header-bar .button.titlebutton:insensitive > .label,
-      .warning .titlebar .button.titlebutton:insensitive > .label,
-      .error .button:insensitive > .label,
-      .error GtkComboBox:insensitive > .label,
-      .error .header-bar .button.titlebutton:insensitive > .label,
-      .error .titlebar .button.titlebutton:insensitive > .label {
+      .info .button:disabled > .label, .info .header-bar .button.titlebutton:disabled > .label,
+      .info .titlebar .button.titlebutton:disabled > .label,
+      .info GtkComboBox:disabled > .label,
+      .question .button:disabled > .label,
+      .question GtkComboBox:disabled > .label,
+      .question .header-bar .button.titlebutton:disabled > .label,
+      .question .titlebar .button.titlebutton:disabled > .label,
+      .warning .button:disabled > .label,
+      .warning GtkComboBox:disabled > .label,
+      .warning .header-bar .button.titlebutton:disabled > .label,
+      .warning .titlebar .button.titlebutton:disabled > .label,
+      .error .button:disabled > .label,
+      .error GtkComboBox:disabled > .label,
+      .error .header-bar .button.titlebutton:disabled > .label,
+      .error .titlebar .button.titlebutton:disabled > .label {
         color: inherit; }
     .info .button:backdrop,
     info GtkComboBox:backdrop,
@@ -6309,40 +6290,40 @@ GtkInfoBar {
       color: alpha(white,0.4);
       border-style: solid;
       border-color: #39393c;
-      background-image: linear-gradient(to bottom, rgba(0,0,0,0.1));
+      background-image: image(rgba(0,0,0,0.1));
       text-shadow: none;
-      icon-shadow: none;
+      -gtk-icon-shadow: none;
       box-shadow: inset 0 1px rgba(255, 255, 255, 0); }
-      .info .button:backdrop:insensitive,
-      .info GtkComboBox:backdrop:insensitive,
-      .question .button:backdrop:insensitive,
-      .question GtkComboBox:backdrop:insensitive,
-      .warning .button:backdrop:insensitive,
-      .warning GtkComboBox:backdrop:insensitive,
-      .error .button:backdrop:insensitive,
-      .error GtkComboBox:backdrop:insensitive {
+      .info .button:backdrop:disabled,
+      .info GtkComboBox:backdrop:disabled,
+      .question .button:backdrop:disabled,
+      .question GtkComboBox:backdrop:disabled,
+      .warning .button:backdrop:disabled,
+      .warning GtkComboBox:backdrop:disabled,
+      .error .button:backdrop:disabled,
+      .error GtkComboBox:backdrop:disabled {
         color: alpha(white,0.5);
         border-style:solid;
         border-color: #39393c;
-        background-image: linear-gradient(to bottom, rgba(0,0,0,0.4));
+        background-image: image(rgba(0,0,0,0.4));
         text-shadow: none;
-        icon-shadow: none;
+        -gtk-icon-shadow: none;
         box-shadow: inset 0 1px rgba(255, 255, 255, 0); }
-        .info .button:backdrop:insensitive > .label, .info .header-bar .button.titlebutton:backdrop:insensitive > .label,
-        .info .titlebar .button.titlebutton:backdrop:insensitive > .label,
-        .info GtkComboBox:backdrop:insensitive > .label,
-        .question .button:backdrop:insensitive > .label,
-        .question .header-bar .button.titlebutton:backdrop:insensitive > .label,
-        .question .titlebar .button.titlebutton:backdrop:insensitive > .label,
-        .question GtkComboBox:backdrop:insensitive > .label,
-        .warning .button:backdrop:insensitive > .label,
-        .warning .header-bar .button.titlebutton:backdrop:insensitive > .label,
-        .warning .titlebar .button.titlebutton:backdrop:insensitive > .label,
-        .warning GtkComboBox:backdrop:insensitive > .label,
-        .error .button:backdrop:insensitive > .label,
-        .error .header-bar .button.titlebutton:backdrop:insensitive > .label,
-        .error .titlebar .button.titlebutton:backdrop:insensitive > .label,
-        .error GtkComboBox:backdrop:insensitive > .label {
+        .info .button:backdrop:disabled > .label, .info .header-bar .button.titlebutton:backdrop:disabled > .label,
+        .info .titlebar .button.titlebutton:backdrop:disabled > .label,
+        .info GtkComboBox:backdrop:disabled > .label,
+        .question .button:backdrop:disabled > .label,
+        .question .header-bar .button.titlebutton:backdrop:disabled > .label,
+        .question .titlebar .button.titlebutton:backdrop:disabled > .label,
+        .question GtkComboBox:backdrop:disabled > .label,
+        .warning .button:backdrop:disabled > .label,
+        .warning .header-bar .button.titlebutton:backdrop:disabled > .label,
+        .warning .titlebar .button.titlebutton:backdrop:disabled > .label,
+        .warning GtkComboBox:backdrop:disabled > .label,
+        .error .button:backdrop:disabled > .label,
+        .error .header-bar .button.titlebutton:backdrop:disabled > .label,
+        .error .titlebar .button.titlebutton:backdrop:disabled > .label,
+        .error GtkComboBox:backdrop:disabled > .label {
           color: inherit; }
   .info .label:selected,
   .info .label:selected:focus,
@@ -6370,15 +6351,15 @@ GtkInfoBar {
   text-shadow: 0 1px black; }
   .tooltip.background {
     background-color: rgba(15,15,19, 0.5);
-  background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2));
+  background-image: image(rgba(0, 0, 0, 0.2));
     background-clip: padding-box;
     border: 1px solid rgba(255, 255, 255, 0.1); }
   .tooltip.window-frame.csd {
-    background-color: transparent; }
+    background-color: #2C2C2E; }
 
 .tooltip * {
   padding: 4px;
-  background-color: transparent;
+  background-color: #2C2C2E;
   color: inherit; }
 
 /*****************
@@ -6471,7 +6452,7 @@ GtkColorSwatch {
                                       shade(#3c3c3e, 0.9)
                                       );     
   text-shadow: 0 -1px rgba(0,0,0,0.7);
-  icon-shadow: 0 -1px rgba(0,0,0,0.7);                                   
+  -gtk-icon-shadow: 0 -1px rgba(0,0,0,0.7);                                   
   box-shadow: 0 1px alpha(white, 0.08) inset,
 				0 2px alpha(white, 0.04) inset,
 				1px 0 alpha(white, 0.03) inset,
@@ -6507,7 +6488,7 @@ GtkColorSwatch {
 				0 -3px alpha(black, 0.01) inset,
 				0 1px 2px 0 rgba(0,0,0,0.2); 
     text-shadow: 0 1px rgba(0,0,0, 0.76923);
-    icon-shadow: 0 1px rgba(0,0,0, 0.76923); }
+    -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923); }
     GtkColorSwatch#add-color-button:backdrop {
       color: @theme_unfocused_fg_color;
     border-color: #202022;
@@ -6533,14 +6514,14 @@ GtkColorSwatch {
 				0 -2px alpha(black, 0.01) inset,
 				0 -3px alpha(black, 0.005) inset;
     text-shadow: none;
-    icon-shadow: none; }
+    -gtk-icon-shadow: none; }
     GtkColorSwatch#add-color-button .overlay {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
       box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0);
       text-shadow: none;
-      icon-shadow: none; }
+      -gtk-icon-shadow: none; }
 
 /********
  * Misc *
@@ -6548,7 +6529,7 @@ GtkColorSwatch {
 .content-view {
   background-color: @theme_base_color; }
   .content-view:hover {
-    -gtk-image-effect: highlight; }
+    -gtk-icon-effect: highlight; }
   .content-view:backdrop {
     background-color: @theme_base_color; }
 
@@ -6602,25 +6583,25 @@ GtkColorSwatch {
 .header-bar .titlebutton.button,
 .titlebar .titlebutton.button {
   text-shadow: 0 1px rgba(255, 255, 255, 0.76923);
-  icon-shadow: 0 1px rgba(255, 255, 255, 0.76923); }
+  -gtk-icon-shadow: 0 1px rgba(255, 255, 255, 0.76923); }
   .header-bar .titlebutton.button:backdrop,
   .titlebar .titlebutton.button:backdrop {
-    icon-shadow: none; }
+    -gtk-icon-shadow: none; }
 
 .ssd .titlebar .titlebutton.button {
   text-shadow: 0 1px rgba(0,0,0, 0.76923);
-  icon-shadow: 0 1px rgba(0,0,0, 0.76923); }
+  -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923); }
 
 .ssd .titlebar .titlebutton.button:backdrop {
-    icon-shadow: none; }
+    -gtk-icon-shadow: none; }
 
 .header-bar.selection-mode .titlebutton.button,
 .titlebar.selection-mode .titlebutton.button {
   text-shadow: 0 -1px rgba(0, 0, 0, 0.54353);
-  icon-shadow: 0 -1px rgba(0, 0, 0, 0.54353); }
+  -gtk-icon-shadow: 0 -1px rgba(0, 0, 0, 0.54353); }
   .header-bar.selection-mode .titlebutton.button:backdrop,
   .titlebar.selection-mode .titlebutton.button:backdrop {
-    icon-shadow: none; }
+    -gtk-icon-shadow: none; }
 
 .titlebar .button.titlebutton,
 .header-bar .button.titlebutton,
@@ -6635,14 +6616,14 @@ GtkColorSwatch {
 .titlebar .button.titlebutton:hover,
 .header-bar .button.titlebutton:hover,
 .titlebar.header-bar .button.titlebutton:hover {
-  icon-shadow: 0 2px 3px rgba(255,255,255,0.95),0 -2px 3px rgba(255,255,255,0.95), 0 1px alpha(white, 0.65);
+  -gtk-icon-shadow: 0 2px 3px rgba(255,255,255,0.95),0 -2px 3px rgba(255,255,255,0.95), 0 1px alpha(white, 0.65);
   background: none;
   border-color: transparent;
   box-shadow: none;
   }
 
 .ssd .titlebar .button.titlebutton:hover {
-  icon-shadow: 0 2px 3px rgba(0,0,0,0.95),0 -2px 3px rgba(0,0,0,0.95), 0 1px alpha(black, 0.65);
+  -gtk-icon-shadow: 0 2px 3px rgba(0,0,0,0.95),0 -2px 3px rgba(0,0,0,0.95), 0 1px alpha(black, 0.65);
   background: none;
   border-color: transparent;
   box-shadow: none;
@@ -6662,7 +6643,7 @@ header-bar .button.titlebutton.close:hover,
   border-color: transparent;
   box-shadow: none;
   color: white;
-  icon-shadow: 0 2px 3px rgba(0,0,0,0.95),0 -2px 3px rgba(0,0,0,0.95), 0 1px alpha(black, 0.65), 0 -1px alpha(black, 0.65);
+  -gtk-icon-shadow: 0 2px 3px rgba(0,0,0,0.95),0 -2px 3px rgba(0,0,0,0.95), 0 1px alpha(black, 0.65), 0 -1px alpha(black, 0.65);
   }
 
 .ssd .titlebar .button.titlebutton:active, .ssd .titlebar .button.titlebutton:checked {
@@ -6670,7 +6651,7 @@ header-bar .button.titlebutton.close:hover,
   border-color: transparent;
   box-shadow: none;
   color: black;
-  icon-shadow: 0 2px 3px rgba(255,255,255,0.95),0 -2px 3px rgba(255,255,255,0.95), 0 1px alpha(white, 0.65), 0 -1px alpha(white, 0.65);
+  -gtk-icon-shadow: 0 2px 3px rgba(255,255,255,0.95),0 -2px 3px rgba(255,255,255,0.95), 0 1px alpha(white, 0.65), 0 -1px alpha(white, 0.65);
   }
   
 .ssd .titlebar .button.titlebutton:backdrop,
@@ -6683,24 +6664,21 @@ header-bar .button.titlebutton.close:hover,
   background-color: @theme_selected_bg_color;
   color: #9d9d9f;
   text-shadow: 0 -1px rgba(0,0,0,0.4);
-  icon-shadow: 0 -1px rgba(0,0,0,0.4);
+  -gtk-icon-shadow: 0 -1px rgba(0,0,0,0.4);
   outline-color: rgba(255, 255, 255, 0.3); }
-  .view:insensitive:selected, GtkCalendar:insensitive:selected, .label:insensitive:selected, .grid-child:insensitive:selected, .entry:insensitive:selected, .menuitem.button.flat:insensitive:selected, .menuitem.sidebar-button.button:insensitive:selected, .header-bar .menuitem.titlebutton.button:insensitive:selected,
-  .titlebar .menuitem.titlebutton.button:insensitive:selected, .list-row:insensitive:selected, .sidebar:insensitive:selected, GtkPlacesSidebar.sidebar .list-row:selected:insensitive .label {
+  .view:disabled:selected, GtkCalendar:disabled:selected, .label:disabled:selected, .grid-child:disabled:selected, .entry:disabled:selected, .menuitem.button.flat:disabled:selected, .menuitem.sidebar-button.button:disabled:selected, .header-bar .menuitem.titlebutton.button:disabled:selected,
+  .titlebar .menuitem.titlebutton.button:disabled:selected, .list-row:disabled:selected, .sidebar:disabled:selected, GtkPlacesSidebar.sidebar .list-row:selected:disabled .label {
     color: shade(@insensitive_fg_color, 1.2); }
   .view:backdrop:selected, GtkCalendar:backdrop:selected, .label:backdrop:selected, .grid-child:backdrop:selected, .entry:backdrop:selected, .menuitem.button.flat:backdrop:selected, .menuitem.sidebar-button.button:backdrop:selected, .header-bar .menuitem.titlebutton.button:backdrop:selected,
   .titlebar .menuitem.titlebutton.button:backdrop:selected, .list-row:backdrop:selected, .sidebar:backdrop:selected {
     color: shade(@theme_unfocused_fg_color, 1.2); }
-    .view:backdrop:insensitive:selected, GtkCalendar:backdrop:insensitive:selected, .label:backdrop:insensitive:selected, .grid-child:backdrop:insensitive:selected, .entry:backdrop:insensitive:selected, .menuitem.button.flat:backdrop:insensitive:selected, .menuitem.sidebar-button.button:backdrop:insensitive:selected, .header-bar .menuitem.titlebutton.button:backdrop:insensitive:selected,
-    .titlebar .menuitem.titlebutton.button:backdrop:insensitive:selected, .list-row:backdrop:insensitive:selected, .sidebar:backdrop:insensitive:selected, GtkPlacesSidebar.sidebar .list-row:selected:insensitive .label:backdrop, GtkPlacesSidebar.sidebar .list-row:selected:backdrop:insensitive .label {
+    .view:backdrop:disabled:selected, GtkCalendar:backdrop:disabled:selected, .label:backdrop:disabled:selected, .grid-child:backdrop:disabled:selected, .entry:backdrop:disabled:selected, .menuitem.button.flat:backdrop:disabled:selected, .menuitem.sidebar-button.button:backdrop:disabled:selected, .header-bar .menuitem.titlebutton.button:backdrop:disabled:selected,
+    .titlebar .menuitem.titlebutton.button:backdrop:disabled:selected, .list-row:backdrop:disabled:selected, .sidebar:backdrop:disabled:selected, GtkPlacesSidebar.sidebar .list-row:selected:disabled .label:backdrop, GtkPlacesSidebar.sidebar .list-row:selected:backdrop:disabled .label {
       color: #4a4a4d; }
-.view:backdrop:insensitive, GtkCalendar:backdrop:insensitive, .label:backdrop:insensitive, .grid-child:backdrop:insensitive, .entry:backdrop:insensitive, .menuitem.button.flat:backdrop:insensitive
-, .menuitem.sidebar-button.button:backdrop:insensitive, .header-bar .menuitem.titlebutton.button:backdrop:insensitive,
-    .titlebar .menuitem.titlebutton.button:backdrop:insensitive, .list-row:backdrop:insensitive, .sidebar:backdrop:insensitive, GtkPlacesSidebar.sidebar .list-row:backdrop:insensitive .label:backdrop:insensitive, GtkPlacesSidebar.sidebar .list-row:backdrop:insensitive .label {
+.view:backdrop:disabled, GtkCalendar:backdrop:disabled, .label:backdrop:disabled, .grid-child:backdrop:disabled, .entry:backdrop:disabled, .menuitem.button.flat:backdrop:disabled
+, .menuitem.sidebar-button.button:backdrop:disabled, .header-bar .menuitem.titlebutton.button:backdrop:disabled,
+    .titlebar .menuitem.titlebutton.button:backdrop:disabled, .list-row:backdrop:disabled, .sidebar:backdrop:disabled, GtkPlacesSidebar.sidebar .list-row:backdrop:disabled .label:backdrop:disabled, GtkPlacesSidebar.sidebar .list-row:backdrop:disabled .label {
       color: #4a4a4d; }
-      
-.monospace {
-  font: Monospace; }
 
 /**********************
  * Touch Copy & Paste *
@@ -6763,12 +6741,12 @@ header-bar .button.titlebutton.close:hover,
   color: #eeeeec;
   border: none;
   background-color: rgba(15,15,19, 0.5);
-  background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2));
+  background-image: image(rgba(0, 0, 0, 0.2));
   background-clip: padding-box;
   outline-color: rgba(238, 238, 236, 0.3);
   box-shadow: none;
   text-shadow: 0 1px black;
-  icon-shadow: 0 1px black; }
+  -gtk-icon-shadow: 0 1px black; }
   .touch-selection:backdrop {
     text-shadow: none; }
   .touch-selection .button, .touch-selection .header-bar .button.titlebutton, .header-bar .touch-selection .button.titlebutton,
@@ -6776,124 +6754,124 @@ header-bar .button.titlebutton.close:hover,
   .titlebar .touch-selection .button.titlebutton {
     color: #eeeeec;
     border-color: rgba(0, 0, 0, 0.6);
-    background-color: transparent;
-    background-image: linear-gradient(to bottom, rgba(15,15,19, 0.5));
+    background-color: #2C2C2E;
+    background-image: image(rgba(15,15,19, 0.5));
     background-clip: padding-box;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0.04);
     text-shadow: 0 1px black;
-    icon-shadow: 0 1px black;
+    -gtk-icon-shadow: 0 1px black;
     outline-color: rgba(238, 238, 236, 0.3); }
     .touch-selection .button:hover {
       color: white;
       border-color: rgba(0, 0, 0, 0.7);
-      background-image: linear-gradient(to bottom, rgba(42,42,48, 0.7));
+      background-image: image(rgba(42,42,48, 0.7));
       background-clip: padding-box;
       box-shadow: inset 0 1px rgba(255, 255, 255, 0.07);
       text-shadow: 0 1px black;
-      icon-shadow: 0 1px black;
+      -gtk-icon-shadow: 0 1px black;
       outline-color: rgba(238, 238, 236, 0.3); }
     .touch-selection .button:active, .touch-selection .button:checked {
       color: white;
       border-color: rgba(0, 0, 0, 0.9);
-      background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.7));
+      background-image: image(rgba(0, 0, 0, 0.7));
       background-clip: padding-box;
       box-shadow: none;
       text-shadow: none;
-      icon-shadow: none;
+      -gtk-icon-shadow: none;
       outline-color: rgba(238, 238, 236, 0.3); }
-    .touch-selection .button:insensitive, .touch-selection .button:backdrop:insensitive {
+    .touch-selection .button:disabled, .touch-selection .button:backdrop:disabled {
       color: #4a4a4d;
       border-color: rgba(0, 0, 0, 0.4);
-      background-image: linear-gradient(to bottom, rgba(15,15,19, 0.15));
+      background-image: image(rgba(15,15,19, 0.15));
       background-clip: padding-box;
       box-shadow: none;
       text-shadow: none;
-      icon-shadow: none; }
+      -gtk-icon-shadow: none; }
     .touch-selection .button:backdrop {
       color: @unfocused_fg_color;
       border-color: rgba(0, 0, 0, 0.5);
-      background-image: linear-gradient(to bottom, rgba(15,15,19, 0.4));
+      background-image: image(rgba(15,15,19, 0.4));
       background-clip: padding-box;
       box-shadow: none;
       text-shadow: none;
-      icon-shadow: none; }
+      -gtk-icon-shadow: none; }
   .touch-selection .check {
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked.png"), url("assets/checkbox-unchecked@2.png")); }
   .touch-selection .check:hover {
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked-hover.png"), url("assets/checkbox-unchecked-hover@2.png")); }
   .touch-selection .check:active {
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked-active.png"), url("assets/checkbox-unchecked-active@2.png")); }
-  .touch-selection .check:insensitive {
-    icon-shadow: none;
+  .touch-selection .check:disabled {
+    -gtk-icon-shadow: none;
     -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked-insensitive.png"), url("assets/checkbox-unchecked-insensitive@2.png")); }
-  .touch-selection .check:inconsistent {
-    icon-shadow: none;
+  .touch-selection .check:indeterminate {
+    -gtk-icon-shadow: none;
     -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed.png"), url("assets/checkbox-mixed@2.png")); }
-  .touch-selection .check:inconsistent:hover {
-    icon-shadow: none;
+  .touch-selection .check:indeterminate:hover {
+    -gtk-icon-shadow: none;
     -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed-hover.png"), url("assets/checkbox-mixed-hover@2.png")); }
-  .touch-selection .check:inconsistent:selected {
-    icon-shadow: none;
+  .touch-selection .check:indeterminate:selected {
+    -gtk-icon-shadow: none;
     -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed-active.png"), url("assets/checkbox-mixed-active@2.png")); }
-  .touch-selection .check:inconsistent:insensitive {
-    icon-shadow: none;
+  .touch-selection .check:indeterminate:disabled {
+    -gtk-icon-shadow: none;
     -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed-insensitive.png"), url("assets/checkbox-mixed-insensitive@2.png")); }
   .touch-selection .check:checked {
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked.png"), url("assets/checkbox-checked@2.png")); }
-  .touch-selection .check:checked:insensitive {
-    icon-shadow: none;
+  .touch-selection .check:checked:disabled {
+    -gtk-icon-shadow: none;
     -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-insensitive.png"), url("assets/checkbox-checked-insensitive@2.png")); }
   .touch-selection .check:checked:hover {
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-hover.png"), url("assets/checkbox-checked-hover@2.png")); }
   .touch-selection .check:checked:active {
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-active.png"), url("assets/checkbox-checked-active@2.png")); }
   .touch-selection .check:backdrop:checked {
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-backdrop.png"), url("assets/checkbox-checked-backdrop@2.png")); }
   .touch-selection .radio {
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     -gtk-icon-source: -gtk-scaled(url("assets/radio-unchecked.png"), url("assets/radio-unchecked@2.png")); }
   .touch-selection .radio:hover {
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     -gtk-icon-source: -gtk-scaled(url("assets/radio-unchecked-hover.png"), url("assets/radio-unchecked-hover@2.png")); }
   .touch-selection .radio:active {
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     -gtk-icon-source: -gtk-scaled(url("assets/radio-unchecked-active.png"), url("assets/radio-unchecked-active@2.png")); }
-  .touch-selection .radio:insensitive {
-    icon-shadow: none;
+  .touch-selection .radio:disabled {
+    -gtk-icon-shadow: none;
     -gtk-icon-source: -gtk-scaled(url("assets/radio-unchecked-insensitive.png"), url("assets/radio-unchecked-insensitive@2.png")); }
-  .touch-selection .radio:inconsistent {
-    icon-shadow: none;
+  .touch-selection .radio:indeterminate {
+    -gtk-icon-shadow: none;
     -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed.png"), url("assets/radio-mixed@2.png")); }
-  .touch-selection .radio:inconsistent:hover {
-    icon-shadow: none;
+  .touch-selection .radio:indeterminate:hover {
+    -gtk-icon-shadow: none;
     -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed-hover.png"), url("assets/radio-mixed-hover@2.png")); }
-  .touch-selection .radio:inconsistent:selected {
-    icon-shadow: none;
+  .touch-selection .radio:indeterminate:selected {
+    -gtk-icon-shadow: none;
     -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed-active.png"), url("assets/radio-mixed-active@2.png")); }
-  .touch-selection .radio:inconsistent:insensitive {
-    icon-shadow: none;
+  .touch-selection .radio:indeterminate:disabled {
+    -gtk-icon-shadow: none;
     -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed-insensitive.png"), url("assets/radio-mixed-insensitive@2.png")); }
   .touch-selection .radio:checked {
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     -gtk-icon-source: -gtk-scaled(url("assets/radio-checked.png"), url("assets/radio-checked@2.png")); }
-  .touch-selection .radio:checked:insensitive {
-    icon-shadow: none;
+  .touch-selection .radio:checked:disabled {
+    -gtk-icon-shadow: none;
     -gtk-icon-source: -gtk-scaled(url("assets/radio-checked-insensitive.png"), url("assets/radio-checked-insensitive@2.png")); }
   .touch-selection .radio:checked:hover {
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     -gtk-icon-source: -gtk-scaled(url("assets/radio-checked-hover.png"), url("assets/radio-checked-hover@2.png")); }
   .touch-selection .radio:checked:active {
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     -gtk-icon-source: -gtk-scaled(url("assets/radio-checked-active.png"), url("assets/radio-checked-active@2.png")); }
   .touch-selection .radio:backdrop:checked {
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     -gtk-icon-source: -gtk-scaled(url("assets/radio-checked-backdrop.png"), url("assets/radio-checked-backdrop@2.png")); }
 
 .overshoot.top {
@@ -6901,7 +6879,7 @@ header-bar .button.titlebutton.close:hover,
   background-size: 100% 5%, 100% 100%;
   background-repeat: no-repeat;
   background-position: center top;
-  background-color: transparent;
+  background-color: #2C2C2E;
   border: none;
   box-shadow: none; }
   
@@ -6910,7 +6888,7 @@ header-bar .button.titlebutton.close:hover,
     background-size: 100% 5%;
     background-repeat: no-repeat;
     background-position: center top;
-    background-color: transparent;
+    background-color: #2C2C2E;
     border: none;
     box-shadow: none; }
 .overshoot.bottom {
@@ -6918,7 +6896,7 @@ header-bar .button.titlebutton.close:hover,
   background-size: 100% 5%, 100% 100%;
   background-repeat: no-repeat;
   background-position: center bottom;
-  background-color: transparent;
+  background-color: #2C2C2E;
   border: none;
   box-shadow: none; }
   
@@ -6927,7 +6905,7 @@ header-bar .button.titlebutton.close:hover,
     background-size: 100% 5%;
     background-repeat: no-repeat;
     background-position: center bottom;
-    background-color: transparent;
+    background-color: #2C2C2E;
     border: none;
     box-shadow: none; }
 .overshoot.left {
@@ -6935,7 +6913,7 @@ header-bar .button.titlebutton.close:hover,
   background-size: 5% 100%, 100% 100%;
   background-repeat: no-repeat;
   background-position: left center;
-  background-color: transparent;
+  background-color: #2C2C2E;
   border: none;
   box-shadow: none; }
   .overshoot.left:backdrop {
@@ -6943,7 +6921,7 @@ header-bar .button.titlebutton.close:hover,
     background-size: 5% 100%;
     background-repeat: no-repeat;
     background-position: left center;
-    background-color: transparent;
+    background-color: #2C2C2E;
     border: none;
     box-shadow: none; }
 .overshoot.right {
@@ -6951,7 +6929,7 @@ header-bar .button.titlebutton.close:hover,
   background-size: 5% 100%, 100% 100%;
   background-repeat: no-repeat;
   background-position: right center;
-  background-color: transparent;
+  background-color: #2C2C2E;
   border: none;
   box-shadow: none; }
   .overshoot.right:backdrop {
@@ -6959,12 +6937,12 @@ header-bar .button.titlebutton.close:hover,
     background-size: 5% 100%;
     background-repeat: no-repeat;
     background-position: right center;
-    background-color: transparent;
+    background-color: #2C2C2E;
     border: none;
     box-shadow: none; }
 
 .undershoot.top {
-  background-color: transparent;
+  background-color: #2C2C2E;
   background-image: linear-gradient(to left, rgba(255, 255, 255, 0.1) 50%, rgba(0, 0, 0, 0.1) 50%);
   padding-top: 1px;
   background-size: 10px 1px;
@@ -6972,7 +6950,7 @@ header-bar .button.titlebutton.close:hover,
   background-origin: content-box;
   background-position: center top; }
 .undershoot.bottom {
-  background-color: transparent;
+  background-color: #2C2C2E;
   background-image: linear-gradient(to left, rgba(255, 255, 255, 0.1) 50%, rgba(0, 0, 0, 0.1) 50%);
   padding-bottom: 1px;
   background-size: 10px 1px;
@@ -6980,7 +6958,7 @@ header-bar .button.titlebutton.close:hover,
   background-origin: content-box;
   background-position: center bottom; }
 .undershoot.left {
-  background-color: transparent;
+  background-color: #2C2C2E;
   background-image: linear-gradient(to top, rgba(255, 255, 255, 0.1) 50%, rgba(0, 0, 0, 0.1) 50%);
   padding-left: 1px;
   background-size: 1px 10px;
@@ -6988,7 +6966,7 @@ header-bar .button.titlebutton.close:hover,
   background-origin: content-box;
   background-position: left center; }
 .undershoot.right {
-  background-color: transparent;
+  background-color: #2C2C2E;
   background-image: linear-gradient(to top, rgba(255, 255, 255, 0.1) 50%, rgba(0, 0, 0, 0.1) 50%);
   padding-right: 1px;
   background-size: 1px 10px;
@@ -6998,10 +6976,10 @@ header-bar .button.titlebutton.close:hover,
   
 /* Brasero */
 BraseroLayout > GtkPaned > GtkBox > BraseroProject > GtkNotebook > GtkFrame > GtkEventBox {
-	background-image: linear-gradient(to bottom, @theme_bg_color);
+	background-image: image(@theme_bg_color);
 	}
 BraseroLayout > GtkPaned > GtkBox > BraseroProject > GtkNotebook > GtkFrame > GtkEventBox:backdrop {
-	background-image: linear-gradient(to bottom, shade(@theme_bg_color,0.95));
+	background-image: image(shade(@theme_bg_color,0.95));
 	}
 
 BraseroProject GtkTextView.view {
@@ -7068,8 +7046,8 @@ GtkFileChooserDialog .search-bar .path-bar .button:checked:last-child,
 GtkFileChooserDialog .search-bar .path-bar .button:checked:hover:last-child,
 GtkFileChooserDialog .search-bar .path-bar .button:checked:last-child:backdrop,
 GtkFileChooserDialog .search-bar .path-bar .button:checked:hover:last-child:backdrop,
-GtkFileChooserDialog .search-bar .path-bar .button:insensitive:last-child,
-GtkFileChooserDialog .search-bar .path-bar .button:insensitive:last-child:backdrop,
+GtkFileChooserDialog .search-bar .path-bar .button:disabled:last-child,
+GtkFileChooserDialog .search-bar .path-bar .button:disabled:last-child:backdrop,
 NemoPathBar.raised.linked .button:last-child,
 NemoPathBar.raised.linked .button:hover:last-child,
 NemoPathBar.raised.linked .button:last-child:backdrop,
@@ -7082,8 +7060,8 @@ NemoPathBar.raised.linked .button:checked:last-child,
 NemoPathBar.raised.linked .button:checked:hover:last-child,
 NemoPathBar.raised.linked .button:checked:last-child:backdrop,
 NemoPathBar.raised.linked .button:checked:hover:last-child:backdrop,
-NemoPathBar.raised.linked .button:insensitive:last-child,
-NemoPathBar.raised.linked .button:insensitive:last-child:backdrop,
+NemoPathBar.raised.linked .button:disabled:last-child,
+NemoPathBar.raised.linked .button:disabled:last-child:backdrop,
 BraseroLayout BraseroFileChooser GtkPathBar.path-bar.linked .button:last-child,
 BraseroLayout BraseroFileChooser GtkPathBar.path-bar.linked .button:hover:last-child,
 BraseroLayout BraseroFileChooser GtkPathBar.path-bar.linked .button:last-child:backdrop,
@@ -7096,8 +7074,8 @@ BraseroLayout BraseroFileChooser GtkPathBar.path-bar.linked .button:checked:last
 BraseroLayout BraseroFileChooser GtkPathBar.path-bar.linked .button:checked:hover:last-child,
 BraseroLayout BraseroFileChooser GtkPathBar.path-bar.linked .button:checked:last-child:backdrop,
 BraseroLayout BraseroFileChooser GtkPathBar.path-bar.linked .button:checked:hover:last-child:backdrop,
-BraseroLayout BraseroFileChooser GtkPathBar.path-bar.linked .button:insensitive:last-child,
-BraseroLayout BraseroFileChooser GtkPathBar.path-bar.linked .button:insensitive:last-child:backdrop {
+BraseroLayout BraseroFileChooser GtkPathBar.path-bar.linked .button:disabled:last-child,
+BraseroLayout BraseroFileChooser GtkPathBar.path-bar.linked .button:disabled:last-child:backdrop {
   border-left-color: alpha(#fff,0.03);
   }
 
@@ -7106,14 +7084,14 @@ BraseroLayout BraseroFileChooser GtkPathBar.path-bar.linked .button:insensitive:
 .inline-toolbar.toolbar .button.image-button:hover,
 .inline-toolbar.toolbar .button.image-button:active,
 .inline-toolbar.toolbar .button.image-button:active:hover,
-.inline-toolbar.toolbar .button.image-button:insensitive,
-.inline-toolbar.toolbar .button.image-button:active:insensitive,
+.inline-toolbar.toolbar .button.image-button:disabled,
+.inline-toolbar.toolbar .button.image-button:active:disabled,
 .inline-toolbar.toolbar .button.image-button:backdrop,
 .inline-toolbar.toolbar .button.image-button:active:backdrop,
 .inline-toolbar.toolbar .button.image-button:hover:backdrop,
 .inline-toolbar.toolbar .button.image-button:active:hover:backdrop,
-.inline-toolbar.toolbar .button.image-button:insensitive:backdrop,
-.inline-toolbar.toolbar .button.image-button:active:insensitive:backdrop {
+.inline-toolbar.toolbar .button.image-button:disabled:backdrop,
+.inline-toolbar.toolbar .button.image-button:active:disabled:backdrop {
 padding: 3px;
 }
 
@@ -7156,7 +7134,7 @@ ECalBaseShellSidebar EPaned .view:backdrop {
  * floating bar *
  ***************/
 .floating-bar {
-    background-image: linear-gradient(to bottom, alpha(black,0.2));
+    background-image: image(alpha(black,0.2));
     background-color: alpha(@theme_selected_bg_color,0.5);
      border: 1px solid rgba(0,0,0, 0.0);
 
@@ -7188,8 +7166,8 @@ ECalBaseShellSidebar EPaned .view:backdrop {
 }
 
 .floating-bar:backdrop {
-    border-color: transparent;
-    background-image: linear-gradient(to bottom, alpha(black,0.5));
+    border-color: #2C2C2E;
+    background-image: image(alpha(black,0.5));
     box-shadow: none;
 }
 
@@ -7220,8 +7198,6 @@ NemoPlacesTreeView:selected {
 }
 
 NemoWindow .sidebar .view {
-    -GtkWindget-focus-padding: 0;
-    -GtkWidget-focus-line-width: 1;
     -GtkTreeView-vertical-separator: 0;
 	background-color: @theme_bg_color;
 	color: @theme_fg_color;
@@ -7237,7 +7213,7 @@ NemoWindow .sidebar .frame {
 }
 
 NemoWindow > GtkGrid > .pane-separator {
-    background-color: transparent;
+    background-color: #2C2C2E;
     }
 
 NemoWindow .primary-toolbar.toolbar,
@@ -7298,7 +7274,7 @@ NemoWindow .sidebar .view:selected {
 }
 
 .nemo-desktop.nemo-canvas-item:active,
-.nemo-desktop.nemo-canvas-item:prelight,
+.nemo-desktop.nemo-canvas-item:hover,
 .nemo-desktop.nemo-canvas-item:selected {
 	text-shadow: none;
 }*/
@@ -7322,8 +7298,6 @@ NemoWindow GtkStatusbar {
 }
 
 NemoWindow .toolbar .button.image-button {
-    -GtkWidget-focus-line-width: 0;
-    -GtkWidget-focus-padding: 0;
     padding: 4px;
 }
 
@@ -7362,10 +7336,10 @@ NemoWindow .primary-toolbar.toolbar .button.image-button {
 }
 
 .nautilus-desktop.view.nautilus-canvas-item:active,
-.nautilus-desktop.view.nautilus-canvas-item:prelight,
+.nautilus-desktop.view.nautilus-canvas-item:hover,
 .nautilus-desktop.view.nautilus-canvas-item:selected,
 .nemo-desktop.nemo-canvas-item:active,
-.nemo-desktop.nemo-canvas-item:prelight,
+.nemo-desktop.nemo-canvas-item:hover,
 .nemo-desktop.nemo-canvas-item:selected {
     text-shadow: none;
 }
@@ -7511,8 +7485,7 @@ DConfWindow GtkTreeView.view row:selected,
 DConfWindow GtkTreeView.view row:selected:focus,
 DConfWindow GtkTreeView.view row:selected:backdrop,
 DConfWindow GtkTreeView.view row:selected:focus:backdrop {
-    background-image:  linear-gradient(to bottom,
-                                       rgba(15,15,16,0.35));
+    background-image:  image(rgba(15,15,16,0.35));
     color: @theme_fg_color;
     box-shadow: inset 0 -1px rgba(255,255,255,0.04),inset 0 1px rgba(0,0,0,0.15);
 }
@@ -7528,14 +7501,12 @@ DConfWindow DConfKeyView.view row:selected:focus,
 DConfWindow DConfKeyView.view row:selected:backdrop,
 DConfWindow DConfKeyView.view row:selected:hover:backdrop,
 DConfWindow DConfKeyView.view row:selected:focus:backdrop {
-    background-image: linear-gradient(to bottom,
-                                      @theme_selected_bg_color);
+    background-image: image(@theme_selected_bg_color);
     color: @theme_selected_fg_color;
 }
 
 DConfWindow DConfKeyView.view row:hover {
-    background-image:  linear-gradient(to bottom,
-                                       shade(@theme_base_color,0.9));
+    background-image:  image(shade(@theme_base_color,0.9));
     color: #cdcdcf;
 }
 
@@ -7576,7 +7547,7 @@ GeditViewFrame .gedit-search-slider:backdrop {
 .titlebar.header-bar > GtkBox > GtkLabel.label.title {
   color: white;
   text-shadow: 0 -1px rgba(0,0,0,0.7);
-  icon-shadow: 0 -1px rgba(0,0,0,0.7);
+  -gtk-icon-shadow: 0 -1px rgba(0,0,0,0.7);
 }
 
 SushiFontWidget {
@@ -7663,8 +7634,8 @@ CajaDesktopWindow FMDesktopIconView .view {
 	background-color: shade(@theme_bg_color, 0.9);
 }
 
-.caja-inactive-pane .notebook .scrollbar.button:insensitive,
-.caja-inactive-pane .notebook .scrollbar.button:insensitive:backdrop {
+.caja-inactive-pane .notebook .scrollbar.button:disabled,
+.caja-inactive-pane .notebook .scrollbar.button:disabled:backdrop {
 	background-color: transparent;
 	border-radius: 0px;
 }
@@ -7672,7 +7643,7 @@ CajaDesktopWindow FMDesktopIconView .view {
 CajaWindow GtkPaned.horizontal,
 CajaWindow GtkPaned.horizontal:backdrop {
     -GtkPaned-handle-size: 3px;
-    border-color: transparent;
+    border-color: #2C2C2E;
     background-color: @theme_bg_color;
 }
 
@@ -7684,14 +7655,11 @@ CajaWindow GtkScrolledWindow.frame {
 CajaView .expander column:sorted:selected,
 CajaView .expander column:sorted:selected:hover {
 	background-image: none;
-	background-color: transparent;
+	background-color: #2C2C2E;
 }
 
-CajaWindow .floating-bar {
-	font: italic;
-}
 CajaWindow .notebook {
-	/*border-color: shade(@notebook_border, 1.2);*/
+	border-color: shade(@notebook_border, 1.2);
 	border-radius: 0px;
 }
 
@@ -7794,7 +7762,7 @@ CajaWindow CajaNotesViewer .scrollbar.button:backdrop,
 CajaWindow CajaEmblemSidebar .scrollbar.button:backdrop,
 CajaWindow CajaPlacesSidebar .scrollbar.button:backdrop,
 CajaWindow CajaHistorySidebar .scrollbar.button:backdrop {
-    color: transparent;
+    color: #2C2C2E;
 }
 
 CajaWindow FMTreeView .scrollbar.button:hover,
@@ -7899,7 +7867,7 @@ color: @theme_fg_color;
                                       shade(shade(@theme_base_color, 1.8), 0.9)
                                       );     
   text-shadow: 0 -1px rgba(0,0,0,0.7);
-  icon-shadow: 0 -1px rgba(0,0,0,0.7);                                   
+  -gtk-icon-shadow: 0 -1px rgba(0,0,0,0.7);                                   
   box-shadow: 0 1px alpha(white, 0.08) inset,
 				0 2px alpha(white, 0.04) inset,
 				1px 0 alpha(white, 0.03) inset,
@@ -7936,7 +7904,7 @@ color: shade(@theme_fg_color, 1.2);
 				0 -3px alpha(black, 0.01) inset,
 				0 1px 2px 0 rgba(0,0,0,0.2); 
     text-shadow: 0 1px rgba(0,0,0, 0.76923);
-    icon-shadow: 0 1px rgba(0,0,0, 0.76923); }
+    -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923); }
     
 CajaTrashBar .button:active {
 color: white;
@@ -7948,42 +7916,42 @@ color: white;
                                       mix(shade(shade(@theme_base_color, 1.8), 1.2), @theme_selected_bg_color, 0.25));
     background-color: transparent;
     text-shadow: 0 1px rgba(0,0,0, 0.76923);
-    icon-shadow: 0 1px rgba(0,0,0, 0.76923);
+    -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923);
     box-shadow: inset 0 1px rgba(0, 0, 0, 0.07), inset 0 2px 1px -2px rgba(0, 0, 0, 0.6), 0 1px alpha(white,0.12); }
     
-CajaTrashBar .button:insensitive {
+CajaTrashBar .button:disabled {
 color:alpha(white, 0.6);
       border-style: solid;
       border-color: #363639;
-      background-image: linear-gradient(to bottom, rgba(0,0,0,0.05));
+      background-image: image(rgba(0,0,0,0.05));
       text-shadow: none;
-      icon-shadow: none;
+      -gtk-icon-shadow: none;
       box-shadow:  none; }
       
 CajaTrashBar .button:backdrop {
 color: alpha(white,0.4);
       border-style: solid;
       border-color: #39393c;
-      background-image: linear-gradient(to bottom, rgba(0,0,0,0.1));
+      background-image: image(rgba(0,0,0,0.1));
       text-shadow: none;
-      icon-shadow: none;
+      -gtk-icon-shadow: none;
       box-shadow: inset 0 1px rgba(255, 255, 255, 0);
 }
       
-CajaTrashBar .button:backdrop:insensitive {
+CajaTrashBar .button:backdrop:disabled {
         color: alpha(white,0.5);
         border-style:solid;
         border-color: #39393c;
-        background-image: linear-gradient(to bottom, rgba(0,0,0,0.4));
+        background-image: image(rgba(0,0,0,0.4));
         text-shadow: none;
-        icon-shadow: none;
+        -gtk-icon-shadow: none;
         box-shadow: inset 0 1px rgba(255, 255, 255, 0); 
 }
 
 CajaWindow NautilusQueryEditor .toolbar,
 CajaWindow .notebook NautilusQueryEditor .toolbar {
 	background-image: none;
-	background-color: transparent;
+	background-color: #2C2C2E;
 	padding: 6px 8px;
 }
 
@@ -8005,7 +7973,7 @@ CajaWindow .notebook NautilusQueryEditor .toolbar {
 }
 
 .caja-desktop.nautilus-canvas-item:active,
-.caja-desktop.nautilus-canvas-item:prelight,
+.caja-desktop.nautilus-canvas-item:hover,
 .caja-desktop.nautilus-canvas-item:selected {
 	text-shadow: none;
 }
@@ -8046,13 +8014,13 @@ MatePanelApplet {
 
 /* panel grip */
 PanelToplevel.background.mate-custom-panel-background {
-    background-color: transparent;
+    background-color: #2C2C2E;
     border-radius: 2px;
     }
     
 /* hide buttons */
 PanelToplevel.background.mate-custom-panel-background .button {
-    background: transparent;
+    background: #2C2C2E;
     border-image: none;
     border-width: 0px;
     border-radius: 2px;
@@ -8072,8 +8040,8 @@ PanelToplevel.background.mate-custom-panel-background .button:hover {
 
 /* the grid left from wnckpager and wncktasklist */
 MatePanelAppletFrameDBus {
-    /*background-image: -gtk-scaled(url("assets/panel-grid.svg"));*/
-    background-color: transparent;
+    background-image: -gtk-scaled(url("assets/panel-grid.svg"));
+    background-color: #2C2C2E;
     background-repeat: no-repeat;
     background-position: left;
 }
@@ -8098,7 +8066,7 @@ PanelMenuBar.menubar .menuitem {
 /* set selected menubar button */
 PanelMenuBar.menubar .menuitem:hover {
     background-image: none;
-    background-color: transparent;
+    background-color: #2C2C2E;
     box-shadow: inset 0 -3px @theme_selected_bg_color;
       color: black; 
       font-weight: bold;
@@ -8184,7 +8152,7 @@ WnckTasklist .button {
                                       shade(#3c3c3e, 0.9)
                                       );     
   text-shadow: 0 -1px rgba(0,0,0,0.7);
-  icon-shadow: 0 -1px rgba(0,0,0,0.7);                                   
+  -gtk-icon-shadow: 0 -1px rgba(0,0,0,0.7);                                   
   box-shadow: 0 1px alpha(white, 0.08) inset,
 				0 2px alpha(white, 0.04) inset,
 				1px 0 alpha(white, 0.03) inset,
@@ -8209,7 +8177,7 @@ WnckTasklist .button:active {
                                       mix(shade(#3c3c3e, 1.2), @theme_selected_bg_color, 0.25));
     background-color: transparent;
     text-shadow: 0 1px rgba(0,0,0, 0.76923);
-    icon-shadow: 0 1px rgba(0,0,0, 0.76923);
+    -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923);
     box-shadow: inset 0 1px rgba(0, 0, 0, 0.07), inset 0 2px 1px -2px rgba(0, 0, 0, 0.6), 0 1px alpha(white,0.12);
 }
 
@@ -8241,8 +8209,8 @@ WnckTasklist .button:hover {
 				0 -3px alpha(black, 0.01) inset,
 				0 1px 2px 0 rgba(0,0,0,0.2); 
     text-shadow: 0 1px rgba(0,0,0, 0.76923);
-    icon-shadow: 0 1px rgba(0,0,0, 0.76923);
-    -gtk-image-effect: highlight;
+    -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923);
+    -gtk-icon-effect: highlight;
 }
 
 /* set button WnckSelector */
@@ -8262,7 +8230,7 @@ WnckSelector.menubar .menuitem:hover {
                                       mix(shade(#3c3c3e, 1.2), @theme_selected_bg_color, 0.25));
     background-color: transparent;
     text-shadow: 0 1px rgba(0,0,0, 0.76923);
-    icon-shadow: 0 1px rgba(0,0,0, 0.76923);
+    -gtk-icon-shadow: 0 1px rgba(0,0,0, 0.76923);
     box-shadow: inset 0 1px rgba(0, 0, 0, 0.07), inset 0 2px 1px -2px rgba(0, 0, 0, 0.6), 0 1px alpha(white,0.12);
 }
 
@@ -8289,7 +8257,7 @@ WnckSelector.menubar .menu .menuitem:hover {
 
 WnckPager {
     background-image: none;
-    border-color: transparent;
+    border-color: #2C2C2E;
     background-color: #323234;
     text-shadow: none;
 }
@@ -8318,12 +8286,6 @@ DriveList .button.flat {
     box-shadow: none;
 }
 
-ClockBox,
-.mate-panel-menu-bar.menubar,
-MatePanelApplet > GtkMenuBar.menubar {
-    font: normal;
-}
-
 /* no background for icon-padding area */
 GtkTrayIcon.background {
     background-color: transparent;
@@ -8336,7 +8298,7 @@ NaTrayApplet {
 
 /* system-monitor-applet */
 MatePanelApplet .horizontal .vertical .frame {
-    background-color: transparent;
+    background-color: #2C2C2E;
     border-style: none;
     box-shadow: none;
     border-radius: 0px;
@@ -8368,7 +8330,7 @@ MatePanelApplet .horizontal .vertical .frame {
     margin: 0px;
 }
 
-.mate-panel-applet-slider .frame .button:insensitive {
+.mate-panel-applet-slider .frame .button:disabled {
     color: @insensitive_fg_color;
     background-image: none;
     border-image: none;
@@ -8394,11 +8356,11 @@ TerminalWindow .entry {
 /* Pluma status bar */
 PlumaWindow .button.flat {
     border-color: transparent;
-    background-color: transparent;
+    background-color: #2C2C2E;
     background-image: none;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0);
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
 }
 
 PlumaWindow .button.flat,
@@ -8410,18 +8372,18 @@ PlumaWindow .button.flat:hover {
 PlumaWindow .notebook tab .button.flat,
 PlumaWindow .notebook tab .button.flat:hover {
     border-color: transparent;
-    background-color: transparent;
+    background-color: #2C2C2E;
     background-image: none;
     box-shadow: inset 0 1px rgba(255,255,255,0), 0 1px rgba(255,255,255,0);
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     border-image: none;
 }
 
 PlumaCloseButton.button.flat,
 PlumaCloseButton.button.flat:hover,
-PlumaCloseButton:prelight.button.flat,
-PlumaCloseButton:prelight.button.flat:hover {
+PlumaCloseButton:hover.button.flat,
+PlumaCloseButton:hover.button.flat:hover {
     padding: 0px;
 }
 
@@ -8582,7 +8544,7 @@ EomThumbNav .button.flat:hover:last-child {
                                       #424244);
 }
 
-EomThumbNav .button.flat:insensitive {
+EomThumbNav .button.flat:disabled {
     background-image: none;
     border-color: transparent;
 }
@@ -8602,14 +8564,13 @@ XfceHeading {
 .xfce4-panel {
     background-color: rgba(15,15,16,0.92);
     color: @theme_fg_color;
-    font: normal;
 }
 
 .xfce4-panel .button {
     padding: 0 2px;
     border-radius: 2px;
     background-image: none;
-    background-color: transparent;
+    background-color: #2C2C2E;
     box-shadow: none;
     border-style: none;
     color: @theme_fg_color;
@@ -8629,7 +8590,7 @@ XfceHeading {
 }
 
 .xfce4-panel .menu {
-    -gtk-image-effect: none;
+    -gtk-icon-effect: none;
 }
 
 /* GTK NAMED COLORS

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # DeLorean-Dark-3.18
-latest DeLorean theme for gtk-3.18
+latest DeLorean theme for gtk-3.22
+Only the GNOME Shell theme is working and even that could probably be considered a hackjob.
+
+I have no experience with GTK+ themes whatsoever and I'm not a designer (I lack both skill and talent).
+So GNOME Shell 3.22 users, feel free to download and use this theme!
+
+For changing back to the glass look, see the changes I made where I either:
+    removed "transparent" or
+    replaced it with "#2C2C2E"


### PR DESCRIPTION
Loved the theme and really wanted to use it on my new machine, but it just threw tons of errors. Turns out it had a lot of deprecated / removed / replaced properties and methods in it.
For an exact listing, see the changes.

Main fixes:
- Using image() instead of linear gradient with a single color
- Using -gtk- properties where applicable due to removal/depracation
- Using :disabled instead of :insensitive
- Using :hover instead of :prelight
- Defaulted to metallic colors rather than glass (glass is kind of impaired without a proper fix)
- Removed font properties due to excessive errors and no clear fix

To do:
- [x] Add how-to to switch between Glass and Metallic
- [ ] Fix transparency
- [ ] Fix all themes other than the GTK+3 GNOME Shell theme
- [ ] Figure out why the dark theme files are no longer in use
- [ ] Test on other systems than just one GNOME Shell 3.22